### PR TITLE
fix(work): stand session-guard down after repeated stop-blocks (GH-752)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard-stand-down.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard-stand-down.test.js
@@ -117,6 +117,15 @@ describe('session-guard stand-down (GH-752)', () => {
     assert.equal(rows[0].allow, true);
     assert.equal(rows[0].reason, 'repeat-cap');
     assert.equal(rows[0].meta.count, 4);
+
+    // 5th-and-beyond fires stand down SILENTLY: still exit 0, but no new
+    // conductor line and no new audit row — a long-stalled session cannot
+    // grow the trail without bound.
+    const fifth = await fireStop();
+    assert.equal(fifth.code, 0, '5th fire still allows the stop');
+    assert.doesNotMatch(fifth.stderr, /STAND-DOWN/, 'repeat stand-down is silent');
+    const rowsAfter = readAuditRows().filter((row) => row.action === 'session-guard-stand-down');
+    assert.equal(rowsAfter.length, 1, 'no audit-row growth on repeat stand-downs');
   });
 
   it('workflow progress (fingerprint change) re-arms the counter', async () => {
@@ -137,13 +146,19 @@ describe('session-guard stand-down (GH-752)', () => {
     assert.equal(readSessionFile().standDown.count, 1, 'counter reset on progress');
   });
 
-  it('stands down immediately on a rate-limited stop message', async () => {
+  it('stands down immediately on a rate-limited stop message (announcing once)', async () => {
     await runCli(['init', TICKET, WORKFLOW]);
     const r = await fireStop({ stop_message: 'request failed: API rate limit reached (429)' });
     assert.equal(r.code, 0);
     assert.match(r.stderr, /STAND-DOWN \(rate-limit\)/);
     const rows = readAuditRows().filter((row) => row.action === 'session-guard-stand-down');
     assert.equal(rows[0].reason, 'rate-limit');
+
+    const again = await fireStop({ stop_message: 'request failed: API rate limit reached (429)' });
+    assert.equal(again.code, 0);
+    assert.doesNotMatch(again.stderr, /STAND-DOWN/, 'repeat rate-limit stand-down is silent');
+    const rowsAfter = readAuditRows().filter((row) => row.action === 'session-guard-stand-down');
+    assert.equal(rowsAfter.length, 1, 'one audit row per stand-down reason');
   });
 
   it('stands down immediately when the transcript tail shows a rate limit', async () => {

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard-stand-down.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard-stand-down.test.js
@@ -1,0 +1,179 @@
+'use strict';
+
+/**
+ * Tests for session-guard stand-down (GH-752, outcome-verification Phase 1.1).
+ *
+ * Behavior under test (session-guard/stand-down.js wired into handleStop):
+ *  - fires 1..CAP with an unchanged workflow fingerprint still BLOCK (exit 2);
+ *  - the fire after the cap STANDS DOWN (exit 0) with one conductor line;
+ *  - workflow-state progress (fingerprint change) re-arms the counter;
+ *  - rate-limit stops (stop message or transcript tail) stand down immediately;
+ *  - an abandoned workflow (stale .work-state.json mtime) stands down immediately;
+ *  - every stand-down writes an enforcement audit row.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnHook } = require('./_helpers/run-hook');
+
+const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'session-guard.js');
+const SESSION_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'session-guard-standdown-'));
+const TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'session-guard-standdown-tasks-'));
+const TICKET = 'TEST-SD-1';
+const WORKFLOW = '/work';
+
+function cleanupAllSessions() {
+  try {
+    for (const f of fs.readdirSync(SESSION_DIR)) {
+      if (f.startsWith('claude-session-guard-')) fs.unlinkSync(path.join(SESSION_DIR, f));
+    }
+  } catch {
+    /* ignore */
+  }
+}
+
+function ticketDir() {
+  const dir = path.join(TASKS_BASE, TICKET);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function resetTicketDir() {
+  fs.rmSync(path.join(TASKS_BASE, TICKET), { recursive: true, force: true });
+  ticketDir();
+}
+
+function baseEnv(extra = {}) {
+  return {
+    SESSION_GUARD_DIR: SESSION_DIR,
+    SESSION_GUARD_TICKET_ID: TICKET,
+    TASKS_BASE,
+    CLAUDE_CODE_SESSION_ID: undefined,
+    ...extra,
+  };
+}
+
+function runCli(args, extraEnv = {}) {
+  return spawnHook(HOOK_PATH, null, baseEnv(extraEnv), { args });
+}
+
+function fireStop(hookData = {}, extraEnv = {}) {
+  return spawnHook(
+    HOOK_PATH,
+    { session_id: 'test-session', ...hookData },
+    baseEnv({ ...extraEnv, CLAUDE_HOOK_TYPE: 'Stop' })
+  );
+}
+
+function readAuditRows() {
+  try {
+    return JSON.parse(fs.readFileSync(path.join(TASKS_BASE, TICKET, '.work-actions.json'), 'utf8'));
+  } catch {
+    return [];
+  }
+}
+
+function readSessionFile() {
+  return JSON.parse(
+    fs.readFileSync(path.join(SESSION_DIR, `claude-session-guard-${TICKET}.json`), 'utf8')
+  );
+}
+
+describe('session-guard stand-down (GH-752)', () => {
+  before(() => {
+    fs.mkdirSync(SESSION_DIR, { recursive: true });
+  });
+  after(() => {
+    cleanupAllSessions();
+    fs.rmSync(SESSION_DIR, { recursive: true, force: true });
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+  beforeEach(() => {
+    cleanupAllSessions();
+    resetTicketDir();
+  });
+
+  it('blocks fires 1-3, stands down on the 4th identical block, and audits it', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+
+    for (let fire = 1; fire <= 3; fire++) {
+      const r = await fireStop();
+      assert.equal(r.code, 2, `fire ${fire} must still block`);
+      assert.doesNotMatch(r.stderr, /STAND-DOWN/, `fire ${fire} must not mention stand-down`);
+    }
+
+    const fourth = await fireStop();
+    assert.equal(fourth.code, 0, '4th identical block must allow the stop');
+    assert.match(fourth.stderr, /STAND-DOWN \(repeat-cap\)/);
+    assert.match(fourth.stderr, new RegExp(TICKET));
+
+    assert.equal(readSessionFile().standDown.count, 4);
+
+    const rows = readAuditRows().filter((row) => row.action === 'session-guard-stand-down');
+    assert.equal(rows.length, 1, 'exactly one stand-down audit row');
+    assert.equal(rows[0].allow, true);
+    assert.equal(rows[0].reason, 'repeat-cap');
+    assert.equal(rows[0].meta.count, 4);
+  });
+
+  it('workflow progress (fingerprint change) re-arms the counter', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+
+    for (let fire = 1; fire <= 3; fire++) {
+      assert.equal((await fireStop()).code, 2);
+    }
+
+    // Progress: the workflow state moves to a different step/task.
+    fs.writeFileSync(
+      path.join(ticketDir(), '.work-state.json'),
+      JSON.stringify({ currentStep: 9, tasksMeta: { currentTaskIndex: 2 } })
+    );
+
+    const afterProgress = await fireStop();
+    assert.equal(afterProgress.code, 2, 'fingerprint changed — guard re-arms and blocks again');
+    assert.equal(readSessionFile().standDown.count, 1, 'counter reset on progress');
+  });
+
+  it('stands down immediately on a rate-limited stop message', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+    const r = await fireStop({ stop_message: 'request failed: API rate limit reached (429)' });
+    assert.equal(r.code, 0);
+    assert.match(r.stderr, /STAND-DOWN \(rate-limit\)/);
+    const rows = readAuditRows().filter((row) => row.action === 'session-guard-stand-down');
+    assert.equal(rows[0].reason, 'rate-limit');
+  });
+
+  it('stands down immediately when the transcript tail shows a rate limit', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+    const transcript = path.join(TASKS_BASE, 'transcript.jsonl');
+    fs.writeFileSync(transcript, '{"type":"error","error":{"type":"overloaded_error"}}\n');
+    const r = await fireStop({ transcript_path: transcript });
+    assert.equal(r.code, 0);
+    assert.match(r.stderr, /STAND-DOWN \(rate-limit\)/);
+  });
+
+  it('stands down immediately on an abandoned workflow (stale state mtime)', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+    const stateFile = path.join(ticketDir(), '.work-state.json');
+    fs.writeFileSync(stateFile, JSON.stringify({ currentStep: 9 }));
+    const past = new Date(Date.now() - 60_000);
+    fs.utimesSync(stateFile, past, past);
+
+    const r = await fireStop({}, { WORK_GUARD_ABANDON_MS: '1000' });
+    assert.equal(r.code, 0);
+    assert.match(r.stderr, /STAND-DOWN \(abandoned\)/);
+  });
+
+  it('a fresh state file does not trip the abandonment detector', async () => {
+    await runCli(['init', TICKET, WORKFLOW]);
+    fs.writeFileSync(
+      path.join(ticketDir(), '.work-state.json'),
+      JSON.stringify({ currentStep: 9 })
+    );
+    const r = await fireStop({}, { WORK_GUARD_ABANDON_MS: String(60 * 60 * 1000) });
+    assert.equal(r.code, 2, 'recent state — normal block');
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/hook-handlers.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/hook-handlers.js
@@ -20,6 +20,7 @@ const {
   readWorkState,
 } = require(path.join(__dirname, 'context'));
 const { findActiveSessions } = require(path.join(__dirname, 'store'));
+const { assessStop, surfaceStandDown } = require(path.join(__dirname, 'stand-down'));
 
 /**
  * Active sessions owned by THIS terminal/worktree. Sessions owned by a
@@ -219,7 +220,17 @@ function handleStop(hookData) {
     return;
   }
 
-  blockStop(nonCheckSessions[0]);
+  // GH-752 stand-down: the guard's value lives in the first few fires. On a
+  // rate-limited/abandoned session, or past the identical-consecutive-block
+  // cap, allow the stop and surface once instead of re-firing forever.
+  const session = nonCheckSessions[0];
+  const verdict = assessStop(hookData, session);
+  if (verdict.action === 'stand-down') {
+    surfaceStandDown(verdict, session);
+    process.exit(0);
+    return;
+  }
+  blockStop(session);
 }
 
 module.exports = { handlePreCompact, handleStop };

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/stand-down.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/stand-down.js
@@ -31,8 +31,14 @@ const getConfig = require(path.join(__dirname, '..', '..', 'get-config'));
 const { readTicketArtifact } = require(path.join(__dirname, 'context'));
 const { writeSessionAtomic } = require(path.join(__dirname, 'store'));
 
-const STAND_DOWN_CAP = Number.parseInt(process.env.WORK_GUARD_STAND_DOWN_CAP, 10) || 3;
-const ABANDON_MS = Number.parseInt(process.env.WORK_GUARD_ABANDON_MS, 10) || 4 * 60 * 60 * 1000;
+// NaN-guarded (not `||`) so an explicit 0 is honored: CAP=0 stands down on
+// the first identical fire; ABANDON_MS=0 treats any stopped session as
+// abandoned. The guard blocks CAP times; the (CAP+1)th identical fire stands
+// down.
+const _cap = Number.parseInt(process.env.WORK_GUARD_STAND_DOWN_CAP, 10);
+const STAND_DOWN_CAP = Number.isNaN(_cap) ? 3 : _cap;
+const _abandonMs = Number.parseInt(process.env.WORK_GUARD_ABANDON_MS, 10);
+const ABANDON_MS = Number.isNaN(_abandonMs) ? 4 * 60 * 60 * 1000 : _abandonMs;
 const TRANSCRIPT_TAIL_BYTES = 8192;
 
 // Rate-limit / API-error markers. Kept deliberately narrow: a stand-down on a
@@ -43,19 +49,26 @@ const RATE_LIMIT_RE =
 /** Read the last chunk of a transcript file; '' on any failure. */
 function readTranscriptTail(transcriptPath) {
   if (!transcriptPath) return '';
+  let fd;
   try {
-    const stat = fs.statSync(transcriptPath);
+    // Open first, then fstat the descriptor — no check-then-use window
+    // between stat and read (CodeQL js/file-system-race).
+    fd = fs.openSync(transcriptPath, 'r');
+    const stat = fs.fstatSync(fd);
     const start = Math.max(0, stat.size - TRANSCRIPT_TAIL_BYTES);
-    const fd = fs.openSync(transcriptPath, 'r');
-    try {
-      const buf = Buffer.alloc(stat.size - start);
-      fs.readSync(fd, buf, 0, buf.length, start);
-      return buf.toString('utf8');
-    } finally {
-      fs.closeSync(fd);
-    }
+    const buf = Buffer.alloc(stat.size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    return buf.toString('utf8');
   } catch {
     return '';
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fs.closeSync(fd);
+      } catch {
+        /* already closed */
+      }
+    }
   }
 }
 
@@ -115,39 +128,64 @@ function detectImmediateReason(hookData, session, now) {
   return null;
 }
 
-/**
- * Decide block vs stand-down for one Stop fire and persist the counter.
- * @returns {{ action: 'block'|'stand-down', reason?: string, fingerprint: string, count: number }}
- */
-function assessStop(hookData, session, now = Date.now()) {
-  const fingerprint = computeBlockFingerprint(session);
-
-  const immediate = detectImmediateReason(hookData, session, now);
-  if (immediate) {
-    return { action: 'stand-down', reason: immediate, fingerprint, count: 0 };
-  }
-
-  const prior = session.standDown;
-  const count = prior && prior.fingerprint === fingerprint ? prior.count + 1 : 1;
-  try {
-    writeSessionAtomic(session.ticketId, {
-      ...session,
-      standDown: { fingerprint, count, lastAt: new Date(now).toISOString() },
+/** Immediate stand-down (rate-limit/abandoned): announce once per reason. */
+function standDownImmediately(session, prior, reason, fingerprint) {
+  const announce = !(prior && prior.announcedReason === reason);
+  if (announce) {
+    persistStandDown(session, {
+      ...(prior || { fingerprint, count: 0 }),
+      announcedReason: reason,
     });
+  }
+  return { action: 'stand-down', reason, fingerprint, count: prior?.count || 0, announce };
+}
+
+/** Persist the stand-down bookkeeping on the session file; never throws. */
+function persistStandDown(session, standDown) {
+  try {
+    writeSessionAtomic(session.ticketId, { ...session, standDown });
   } catch {
     /* counter persistence is best-effort — never break the hook */
   }
+}
+
+/**
+ * Decide block vs stand-down for one Stop fire and persist the counter.
+ * `announce` is true only on the FIRST stand-down for a given reason +
+ * fingerprint — later fires stand down silently, so a long-stalled session
+ * cannot grow the audit trail without bound.
+ * @returns {{ action: 'block'|'stand-down', reason?: string,
+ *             fingerprint: string, count: number, announce?: boolean }}
+ */
+function assessStop(hookData, session, now = Date.now()) {
+  const fingerprint = computeBlockFingerprint(session);
+  const prior = session.standDown;
+
+  const immediate = detectImmediateReason(hookData, session, now);
+  if (immediate) return standDownImmediately(session, prior, immediate, fingerprint);
+
+  const count = prior && prior.fingerprint === fingerprint ? prior.count + 1 : 1;
+  persistStandDown(session, { fingerprint, count, lastAt: new Date(now).toISOString() });
 
   if (count > STAND_DOWN_CAP) {
-    return { action: 'stand-down', reason: 'repeat-cap', fingerprint, count };
+    return {
+      action: 'stand-down',
+      reason: 'repeat-cap',
+      fingerprint,
+      count,
+      announce: count === STAND_DOWN_CAP + 1,
+    };
   }
   return { action: 'block', fingerprint, count };
 }
 
 /**
- * Surface ONE conductor-visible line and audit the stand-down. Never throws.
+ * Surface ONE conductor-visible line and audit the stand-down — only on the
+ * announcing fire (verdict.announce); repeats stand down silently. Never
+ * throws.
  */
 function surfaceStandDown(verdict, session) {
+  if (!verdict.announce) return;
   const workflow = session.workflow || '/work';
   process.stderr.write(
     `[session-guard] STAND-DOWN (${verdict.reason}): allowing stop for ${session.ticketId} ` +

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard/stand-down.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard/stand-down.js
@@ -1,0 +1,182 @@
+'use strict';
+
+/**
+ * session-guard/stand-down.js — Stop-hook stand-down policy (GH-752,
+ * outcome-verification Phase 1.1).
+ *
+ * The guard's quality function lives in stop-block fires 1–3; everything past
+ * that is harm (one GH-690 session collected 226 consecutive "DO NOT STOP"
+ * blocks, including while rate-limited). This module decides, per Stop fire,
+ * whether the guard should BLOCK (normal) or STAND DOWN (allow the stop and
+ * surface one line for the conductor):
+ *
+ *   - immediately, when the stop is caused by a rate limit / API error
+ *     (stop message or transcript tail), or when the workflow looks abandoned
+ *     (no state-file progress for WORK_GUARD_ABANDON_MS);
+ *   - after WORK_GUARD_STAND_DOWN_CAP identical consecutive blocks — where
+ *     "identical" means the workflow-state fingerprint (step, dispatch marker,
+ *     current task) has not moved between fires. Any progress re-arms the
+ *     guard by resetting the counter.
+ *
+ * The consecutive-block counter persists in the session store file
+ * (`standDown: { fingerprint, count, lastAt }`); every stand-down decision is
+ * audited to `.work-actions.json` as an enforcement row
+ * (`action: session-guard-stand-down`, `allow: true`).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const getConfig = require(path.join(__dirname, '..', '..', 'get-config'));
+const { readTicketArtifact } = require(path.join(__dirname, 'context'));
+const { writeSessionAtomic } = require(path.join(__dirname, 'store'));
+
+const STAND_DOWN_CAP = Number.parseInt(process.env.WORK_GUARD_STAND_DOWN_CAP, 10) || 3;
+const ABANDON_MS = Number.parseInt(process.env.WORK_GUARD_ABANDON_MS, 10) || 4 * 60 * 60 * 1000;
+const TRANSCRIPT_TAIL_BYTES = 8192;
+
+// Rate-limit / API-error markers. Kept deliberately narrow: a stand-down on a
+// false positive only ends one stop-block loop; a miss costs three more fires.
+const RATE_LIMIT_RE =
+  /rate.?limit|overloaded_error|too many requests|quota exceeded|usage limit reached|\b(?:429|529)\b/i;
+
+/** Read the last chunk of a transcript file; '' on any failure. */
+function readTranscriptTail(transcriptPath) {
+  if (!transcriptPath) return '';
+  try {
+    const stat = fs.statSync(transcriptPath);
+    const start = Math.max(0, stat.size - TRANSCRIPT_TAIL_BYTES);
+    const fd = fs.openSync(transcriptPath, 'r');
+    try {
+      const buf = Buffer.alloc(stat.size - start);
+      fs.readSync(fd, buf, 0, buf.length, start);
+      return buf.toString('utf8');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return '';
+  }
+}
+
+/** mtime (epoch ms) of a per-ticket artifact, or null when unreadable. */
+function ticketArtifactMtime(ticketId, fileName) {
+  try {
+    const tasksBase = getConfig('TASKS_BASE');
+    if (!tasksBase || !ticketId) return null;
+    let safeId = ticketId;
+    try {
+      safeId = require(path.join(__dirname, '..', '..', 'config')).safeTicketId(ticketId);
+    } catch {
+      /* raw id */
+    }
+    const resolved = path.resolve(tasksBase, safeId, fileName);
+    if (!resolved.startsWith(path.resolve(tasksBase) + path.sep)) return null;
+    return fs.statSync(resolved).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Fingerprint of "where the workflow is": while this stays constant across
+ * Stop fires the guard is repeating itself; when it moves, progress happened
+ * and the counter re-arms. Reads .work-state.json best-effort.
+ */
+function progressFields(ws) {
+  const step = ws?.currentStep ?? '';
+  const dispatched = ws?._work2Dispatched ?? '';
+  const taskIdx = ws?.tasksMeta?.currentTaskIndex ?? '';
+  return `:${step}:${dispatched}:${taskIdx}`;
+}
+
+function computeBlockFingerprint(session) {
+  const base = `${session.ticketId}:${session.workflow || ''}`;
+  try {
+    const raw = readTicketArtifact(session.ticketId, '.work-state.json');
+    return raw ? base + progressFields(JSON.parse(raw)) : base;
+  } catch {
+    return base;
+  }
+}
+
+/**
+ * Reasons that stand the guard down on the FIRST fire, without counting:
+ * a blocked stop cannot help when the runtime is rate-limited or the
+ * workflow has been abandoned.
+ */
+function detectImmediateReason(hookData, session, now) {
+  const stopMessage = String(hookData?.stop_message || '');
+  if (RATE_LIMIT_RE.test(stopMessage)) return 'rate-limit';
+  if (RATE_LIMIT_RE.test(readTranscriptTail(hookData?.transcript_path))) return 'rate-limit';
+
+  const stateMtime = ticketArtifactMtime(session.ticketId, '.work-state.json');
+  if (stateMtime !== null && now - stateMtime > ABANDON_MS) return 'abandoned';
+  return null;
+}
+
+/**
+ * Decide block vs stand-down for one Stop fire and persist the counter.
+ * @returns {{ action: 'block'|'stand-down', reason?: string, fingerprint: string, count: number }}
+ */
+function assessStop(hookData, session, now = Date.now()) {
+  const fingerprint = computeBlockFingerprint(session);
+
+  const immediate = detectImmediateReason(hookData, session, now);
+  if (immediate) {
+    return { action: 'stand-down', reason: immediate, fingerprint, count: 0 };
+  }
+
+  const prior = session.standDown;
+  const count = prior && prior.fingerprint === fingerprint ? prior.count + 1 : 1;
+  try {
+    writeSessionAtomic(session.ticketId, {
+      ...session,
+      standDown: { fingerprint, count, lastAt: new Date(now).toISOString() },
+    });
+  } catch {
+    /* counter persistence is best-effort — never break the hook */
+  }
+
+  if (count > STAND_DOWN_CAP) {
+    return { action: 'stand-down', reason: 'repeat-cap', fingerprint, count };
+  }
+  return { action: 'block', fingerprint, count };
+}
+
+/**
+ * Surface ONE conductor-visible line and audit the stand-down. Never throws.
+ */
+function surfaceStandDown(verdict, session) {
+  const workflow = session.workflow || '/work';
+  process.stderr.write(
+    `[session-guard] STAND-DOWN (${verdict.reason}): allowing stop for ${session.ticketId} ` +
+      `after ${verdict.count} identical block(s). The workflow needs attention — ` +
+      `resume with: ${workflow} ${session.ticketId}\n`
+  );
+  try {
+    const { appendEnforcementAudit } = require(
+      path.join(__dirname, '..', '..', '..', 'work', 'lib', 'work-actions')
+    );
+    appendEnforcementAudit(session.ticketId, {
+      origin: 'workflow',
+      task: null,
+      phase: null,
+      action: 'session-guard-stand-down',
+      allow: true,
+      reason: verdict.reason,
+      outputPath: null,
+      meta: { workflow, fingerprint: verdict.fingerprint, count: verdict.count },
+    });
+  } catch {
+    /* audit is best-effort — the stand-down itself must not fail */
+  }
+}
+
+module.exports = {
+  STAND_DOWN_CAP,
+  assessStop,
+  computeBlockFingerprint,
+  detectImmediateReason,
+  surfaceStandDown,
+};


### PR DESCRIPTION
## Existing Behavior

- `handleStop` in `hook-handlers.js` calls `blockStop` unconditionally on every Stop hook fire with no cap.
- Identical consecutive blocks accumulate indefinitely — one GH-690 session logged 226 consecutive "DO NOT STOP" blocks, including during rate-limited periods.
- No distinction is made between a healthy workflow that needs guarding and a stalled or rate-limited one that should be allowed to stop.
- No audit trail exists for stop-block decisions, leaving the GH-751 SLI report blind to this failure class.

## Intended New Behavior

- A new `stand-down.js` module is wired into `handleStop` to decide block vs. stand-down per Stop fire before delegating to `blockStop`.
- Fires 1–3 with an unchanged workflow-state fingerprint (currentStep, _work2Dispatched, tasksMeta.currentTaskIndex) still block normally; the 4th identical fire stands the guard down, exits 0, and emits one conductor-visible stderr line.
- Any fingerprint change (workflow progress) resets the consecutive counter so the guard re-arms fully.
- Rate-limited and API-error stops (matched via stop_message or transcript tail) and abandoned workflows (`.work-state.json` mtime older than `WORK_GUARD_ABANDON_MS`, default 4 h) stand down immediately on the first fire.
- Every stand-down writes an enforcement audit row (`action: session-guard-stand-down`, `allow: true`) to `.work-actions.json` for the GH-751 SLI report.
- Two env knobs control the policy: `WORK_GUARD_STAND_DOWN_CAP` (default 3) and `WORK_GUARD_ABANDON_MS` (default 4 h).

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify the cap (manual smoke)**

1. Init a guard session for a test ticket:
   ```bash
   node plugins/work/scripts/workflows/lib/hooks/session-guard.js init MY-TICKET /work
   ```
2. Fire Stop three times with no workflow-state change — each should exit 2 (block):
   ```bash
   for i in 1 2 3; do
     echo '{"session_id":"s1"}' | CLAUDE_HOOK_TYPE=Stop SESSION_GUARD_TICKET_ID=MY-TICKET \
       node plugins/work/scripts/workflows/lib/hooks/session-guard.js
     echo "exit: $?"
   done
   ```
3. Fire a fourth time — expect exit 0 and a `STAND-DOWN (repeat-cap)` line on stderr.
4. Inspect `.work-actions.json` in the ticket dir for a `session-guard-stand-down` audit row.

**Verify rate-limit stand-down**

```bash
echo '{"session_id":"s1","stop_message":"request failed: API rate limit reached (429)"}' \
  | CLAUDE_HOOK_TYPE=Stop SESSION_GUARD_TICKET_ID=MY-TICKET \
    node plugins/work/scripts/workflows/lib/hooks/session-guard.js
# Expect: exit 0, stderr contains STAND-DOWN (rate-limit)
```

**Verify abandonment stand-down**

```bash
touch -d '5 hours ago' tasks/MY-TICKET/.work-state.json
echo '{"session_id":"s1"}' | CLAUDE_HOOK_TYPE=Stop SESSION_GUARD_TICKET_ID=MY-TICKET \
  node plugins/work/scripts/workflows/lib/hooks/session-guard.js
# Expect: exit 0, stderr contains STAND-DOWN (abandoned)
```

**Env knob override**

```bash
WORK_GUARD_STAND_DOWN_CAP=1 ... # stands down after 1 identical block instead of 3
WORK_GUARD_ABANDON_MS=60000  ... # treats state files older than 60 s as abandoned
```

### Test Results

6 new subprocess tests via the `spawnHook` harness in `session-guard-stand-down.test.js` cover: cap (fires 1–3 block, 4th stands down, audit row written), counter re-arm on fingerprint change, rate-limit via stop_message, rate-limit via transcript tail, abandonment (stale mtime), and fresh state not tripping abandonment. All pass. Existing 65 session-guard tests untouched and green.

Closes #752