### PR TITLE
feat(work): wire WORK_TDD_MODE=outcome boundary verification into implement gate (GH-756)

### DIFF
--- a/plugins/synapsys/tests/audit-triggers.integration.test.js
+++ b/plugins/synapsys/tests/audit-triggers.integration.test.js
@@ -348,7 +348,18 @@ function buildTooBroadStore() {
 test('too-broad-trigger rule flags a trivially short trigger (AC-G4)', () => {
   const { cwd, home } = buildTooBroadStore();
   const { lintStore } = require(CLI);
-  const result = lintStore({ cwd, scope: 'all' });
+  // Pin HOME to the fixture home (same pattern as the tier-comparison test):
+  // an in-process lintStore with scope 'all' otherwise walks the machine's
+  // REAL shared store, whose live memories pair against the too-broad-ci
+  // fixture and fail this test on developer machines.
+  const realHome = process.env.HOME;
+  let result;
+  try {
+    process.env.HOME = home;
+    result = lintStore({ cwd, scope: 'all' });
+  } finally {
+    process.env.HOME = realHome;
+  }
 
   // The broad-trigger memory must NOT appear in `pairs` (R7: distinct rule, not pairwise).
   const broadInPairs = result.pairs.find((p) => p.a === 'too-broad-ci' || p.b === 'too-broad-ci');

--- a/plugins/work/scripts/workflows/check/__tests__/check-outcome-flags.test.js
+++ b/plugins/work/scripts/workflows/check/__tests__/check-outcome-flags.test.js
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * GH-756: the check step must HARD-FAIL on unresolved outcome-verifier
+ * flags. This design is WEAKER than the legacy gates if flags can be
+ * ignored — this test makes that impossible: an unresolved flag entry
+ * forces needs_work at the completion boundary; a waived or re-verified
+ * entry releases it.
+ */
+
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+// TASKS_BASE must be pinned BEFORE check-next.js loads (module-load capture).
+const TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'check-outcome-flags-'));
+process.env.TASKS_BASE = TASKS_BASE;
+
+const { describe, it, beforeEach, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { advanceOrComplete } = require('../check-next');
+const { unresolvedOutcomeFlags, describeUnresolvedFlags } = require('../lib/outcome-flags');
+
+const TICKET = 'TEST-FLAGS-1';
+const STEP_COUNT_LAST_INDEX = 999; // any index at/past the final step completes
+
+function ticketDir() {
+  return path.join(TASKS_BASE, TICKET);
+}
+
+function writeWorkState(state) {
+  fs.mkdirSync(ticketDir(), { recursive: true });
+  fs.writeFileSync(path.join(ticketDir(), '.work-state.json'), JSON.stringify(state));
+}
+
+function finalState() {
+  return { status: 'in_progress', currentStep: '11_output', changesHash: 'x' };
+}
+
+describe('check step outcome-flag hard-fail (GH-756)', () => {
+  beforeEach(() => {
+    fs.rmSync(ticketDir(), { recursive: true, force: true });
+    fs.mkdirSync(ticketDir(), { recursive: true });
+  });
+  after(() => {
+    fs.rmSync(TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('an unresolved flag forces needs_work at the completion boundary', () => {
+    writeWorkState({ outcomeFlags: [{ task: 2, flags: ['tautology'] }] });
+    const result = advanceOrComplete(TICKET, finalState(), STEP_COUNT_LAST_INDEX, {});
+    assert.equal(result.action, 'needs_work');
+    assert.match(result.reason, /unresolved outcome-verifier flags/);
+    assert.match(result.reason, /task 2: tautology/);
+
+    const saved = JSON.parse(fs.readFileSync(path.join(ticketDir(), '.check-state.json'), 'utf8'));
+    assert.equal(saved.status, 'needs_work');
+  });
+
+  it('a waived flag releases the gate; no flags completes', () => {
+    writeWorkState({
+      outcomeFlags: [{ task: 2, flags: ['tautology'], waived: { by: 'operator', reason: 'ok' } }],
+    });
+    const waived = advanceOrComplete(TICKET, finalState(), STEP_COUNT_LAST_INDEX, {});
+    assert.equal(waived.action, 'complete');
+
+    writeWorkState({ outcomeFlags: [] });
+    const clean = advanceOrComplete(TICKET, finalState(), STEP_COUNT_LAST_INDEX, {});
+    assert.equal(clean.action, 'complete');
+  });
+
+  it('missing or unreadable work state never blocks the check step', () => {
+    const result = advanceOrComplete(TICKET, finalState(), STEP_COUNT_LAST_INDEX, {});
+    assert.equal(result.action, 'complete');
+    assert.deepEqual(unresolvedOutcomeFlags(path.join(TASKS_BASE, 'nope')), []);
+  });
+
+  it('flag summary names each task and flag', () => {
+    const text = describeUnresolvedFlags([
+      { task: 1, flags: ['tautology'] },
+      { task: 3, flags: ['runner-unknown', 'no-structured-reporter'] },
+    ]);
+    assert.equal(text, 'task 1: tautology; task 3: runner-unknown, no-structured-reporter');
+  });
+});

--- a/plugins/work/scripts/workflows/check/check-next.js
+++ b/plugins/work/scripts/workflows/check/check-next.js
@@ -53,6 +53,7 @@ try {
 const { runStep, STEPS } = require(path.join(__dirname, 'lib', 'step-registry'));
 const { acquireLock, releaseLock } = require(path.join(__dirname, 'lib', 'report-utils'));
 const { assessTerminalState, recordCompletion } = require(path.join(__dirname, 'lib', 'staleness'));
+const { outcomeFlagGate } = require(path.join(__dirname, 'lib', 'outcome-flags'));
 
 const checkHooksDir = path.join(__dirname, 'hooks');
 
@@ -202,6 +203,8 @@ function handleTerminalState(safeName, state, tasksDir, probes) {
 function advanceOrComplete(safeName, state, stepIdx, probes) {
   const nextIdx = stepIdx + 1;
   if (nextIdx >= STEPS.length) {
+    const flagBlock = outcomeFlagGate(TASKS_BASE, safeName, state, saveState);
+    if (flagBlock) return flagBlock;
     state.status = 'complete';
     recordCompletion(state, probes);
     saveState(safeName, state);
@@ -393,4 +396,5 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { getNextInstruction };
+// advanceOrComplete exported for the GH-756 outcome-flag hard-fail test.
+module.exports = { getNextInstruction, advanceOrComplete };

--- a/plugins/work/scripts/workflows/check/lib/outcome-flags.js
+++ b/plugins/work/scripts/workflows/check/lib/outcome-flags.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * check/lib/outcome-flags.js — unresolved outcome-verifier flags (GH-756;
+ * plan §5.5). Flags are the quality backstop for everything the verifier
+ * advanced UNVERIFIED: the check step REFUSES to complete while any task
+ * still carries unresolved flags. Resolution = the boundary re-verifies
+ * clean (the gate rewrites the task's entry), or an operator waiver
+ * (`waived: { by, reason }` on the entry — audited by whoever sets it).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Read unresolved flag entries from the ticket's work state.
+ * @param {string} ticketDir - `$TASKS_BASE/<ticket>`
+ * @returns {Array<{ task: number, flags: string[] }>}
+ */
+function unresolvedOutcomeFlags(ticketDir) {
+  let state;
+  try {
+    state = JSON.parse(fs.readFileSync(path.join(ticketDir, '.work-state.json'), 'utf8'));
+  } catch {
+    return [];
+  }
+  const entries = Array.isArray(state && state.outcomeFlags) ? state.outcomeFlags : [];
+  return entries.filter((e) => e && Array.isArray(e.flags) && e.flags.length > 0 && !e.waived);
+}
+
+/** Human summary line for the needs_work reason. */
+function describeUnresolvedFlags(entries) {
+  return entries.map((e) => `task ${e.task}: ${e.flags.join(', ')}`).join('; ');
+}
+
+/**
+ * Completion gate used by check-next.js: when unresolved flags exist, mark
+ * the check needs_work (via the caller's saveState) and return the
+ * instruction; null when the completion may proceed.
+ */
+function outcomeFlagGate(tasksBase, safeName, state, saveState) {
+  const unresolved = unresolvedOutcomeFlags(path.join(tasksBase, safeName));
+  if (unresolved.length === 0) return null;
+  state.status = 'needs_work';
+  saveState(safeName, state);
+  return {
+    type: 'check_instruction',
+    action: 'needs_work',
+    state: { ticket: safeName, currentStep: state.currentStep },
+    reason:
+      `Check cannot complete: unresolved outcome-verifier flags — ` +
+      `${describeUnresolvedFlags(unresolved)}. Fix and re-verify the flagged ` +
+      `task(s), or record an operator waiver on the flag entry.`,
+  };
+}
+
+module.exports = { unresolvedOutcomeFlags, describeUnresolvedFlags, outcomeFlagGate };

--- a/plugins/work/scripts/workflows/lib/config-schema.js
+++ b/plugins/work/scripts/workflows/lib/config-schema.js
@@ -57,6 +57,12 @@ const SCHEMA = Object.freeze({
   // ── Feature flags ────────────────────────────────────────────────────────
   ENABLE_SYMLINK: flag01("Enable symlink behavior ('0' off, '1' on)."),
   WORK_TEST_STRATEGY_VALIDATOR: flag01("Gate the tasks-draft Test Strategy validator ('0'/'1')."),
+  WORK_TDD_MODE: enumOf(
+    ['process', 'shadow', 'outcome', ''],
+    'Implement-phase verification mode (GH-750): process = legacy RED/GREEN choreography ' +
+      '(default), shadow = legacy gates + outcome verifier logging with no authority, ' +
+      'outcome = task advance decided by the outcome verifier verdict.'
+  ),
 
   // ── Follow-up behavior ───────────────────────────────────────────────────
   FOLLOW_UP_PR_POLL_REVIEWS: bool('Poll PR reviews during follow-up.'),

--- a/plugins/work/scripts/workflows/lib/outcome-verdicts.js
+++ b/plugins/work/scripts/workflows/lib/outcome-verdicts.js
@@ -53,6 +53,7 @@ const FLAG_KINDS = Object.freeze({
   tautology: 'tautology',
   runnerUnknown: 'runner-unknown',
   scopeResolutionFailed: 'scope-resolution-failed',
+  noTestFilesInDiff: 'no-test-files-in-diff',
 });
 
 /**

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-755-source-only-diff-no-derived-tests.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-755-source-only-diff-no-derived-tests.json
@@ -1,0 +1,39 @@
+{
+  "name": "gh-755-source-only-diff-no-derived-tests",
+  "incident": "GH-755",
+  "incidentClass": 2,
+  "taskKind": "tdd-code",
+  "description": "Review finding on the Phase 2 verifier: a tdd-code task whose diff touches only source files (its coverage lives in pre-existing tests untouched by this task) must NOT be contradicted as '0 tests ran' — no run happened. Absence of derived-test evidence is a flag for task_review scrutiny, never a block; only a REAL runner reporting 0 executed tests (GH-749) contradicts I4.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": ["src/service/rate-limiter.js"],
+      "scopeGlobs": ["src/service/**"],
+      "outOfScope": []
+    },
+    "deliverables": { "promised": [], "missing": [] },
+    "baseRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "notes": "no derived test files to overlay"
+    },
+    "headRun": {
+      "attempted": false,
+      "supported": true,
+      "outcome": "not-run",
+      "reporterKind": "none",
+      "notes": "no test files derived from the diff"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["no-test-files-in-diff"],
+    "rationale": "The task changed real in-scope source but authored no tests: fail-on-base is unprovable (absence of evidence, not contradiction) — advance with a flag so task_review checks whether existing coverage genuinely exercises the change."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/755",
+    "notes": "Fixture-before-fix for the code-review finding on PR #761 (fixed in PR #762): the synthetic zero-derived-tests observation previously fabricated a structured pass with testsRan 0, which I4 falsely contradicted — recreating the false-block class the plan eliminates."
+  }
+}

--- a/plugins/work/scripts/workflows/task-verify/__tests__/outcome-gate.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/outcome-gate.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+/**
+ * Outcome-gate tests (GH-756): in WORK_TDD_MODE=outcome, task advance is
+ * decided by the verifier verdict over a REAL repo boundary — VERIFIED and
+ * UNVERIFIED advance (flags recorded on the work state), CONTRADICTED rides
+ * the existing typed exits (retry guidance / planner hold), and verifier
+ * mechanism failures advance with a flag instead of blocking.
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { runOutcomeGate, recordOutcomeFlags } = require('../outcome-gate');
+const { VERDICTS } = require('../../lib/outcome-verdicts');
+
+let ROOT;
+let REPO;
+let TASKS_DIR;
+let baseSha;
+
+function git(args) {
+  return execFileSync('git', ['-C', REPO, ...args], { encoding: 'utf-8', stdio: 'pipe' }).trim();
+}
+
+function write(rel, content) {
+  const full = path.join(REPO, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+before(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'outcome-gate-test-'));
+  REPO = path.join(ROOT, 'repo');
+  TASKS_DIR = path.join(ROOT, 'tasks', 'TEST-OG-1');
+  fs.mkdirSync(REPO, { recursive: true });
+  fs.mkdirSync(TASKS_DIR, { recursive: true });
+  process.env.TASKS_BASE = path.join(ROOT, 'tasks');
+
+  git(['init', '-q']);
+  git(['config', 'user.email', 't@example.com']);
+  git(['config', 'user.name', 'T']);
+  write('package.json', JSON.stringify({ name: 't', scripts: { test: 'node --test' } }));
+  write('src/calc.js', 'module.exports = { mul: (a, b) => a + b };\n');
+  git(['add', '-A']);
+  git(['commit', '-qm', 'base: buggy mul']);
+  baseSha = git(['rev-parse', 'HEAD']);
+
+  // The real task: fix + test.
+  write('src/calc.js', 'module.exports = { mul: (a, b) => a * b };\n');
+  write(
+    'src/__tests__/calc.test.js',
+    [
+      "const { test } = require('node:test');",
+      "const assert = require('node:assert/strict');",
+      "const { mul } = require('../calc.js');",
+      "test('mul multiplies', () => { assert.equal(mul(3, 4), 12); });",
+      '',
+    ].join('\n')
+  );
+  git(['add', '-A']);
+  git(['commit', '-qm', 'task 1: fix mul']);
+
+  fs.writeFileSync(path.join(TASKS_DIR, '.last-commit-sha'), baseSha);
+  fs.writeFileSync(
+    path.join(TASKS_DIR, 'tasks.md'),
+    [
+      '## Task 1 — Fix mul',
+      '### Type',
+      'backend',
+      '### Files in scope',
+      '- src/**',
+      '### Dependencies',
+      'None',
+      '',
+    ].join('\n')
+  );
+});
+
+after(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+function makeHarness() {
+  const ws = { tasksMeta: { tasks: [{ id: 'task_1', status: 'in_progress' }] } };
+  const saved = [];
+  const retries = [];
+  return {
+    ws,
+    saved,
+    retries,
+    input: {
+      safeName: 'TEST-OG-1',
+      ws,
+      tasksDir: TASKS_DIR,
+      taskNum: 1,
+      taskType: 'tdd-code',
+      repoDir: REPO,
+      saveWorkState: (name, state) => saved.push({ name, state }),
+      recordRetry: (reason, extras) => retries.push({ reason, extras }),
+    },
+  };
+}
+
+beforeEach(() => {
+  // Reap any per-test base worktree so runs stay independent.
+  const wt = path.join(TASKS_DIR, `.task-verify-base-${path.basename(REPO)}`);
+  try {
+    execFileSync('git', ['-C', REPO, 'worktree', 'remove', '--force', wt], { stdio: 'pipe' });
+  } catch {
+    /* not created yet */
+  }
+});
+
+describe('outcome-gate (GH-756)', () => {
+  it('VERIFIED real work advances with no flags and an allow audit row', () => {
+    const h = makeHarness();
+    const outcome = runOutcomeGate(h.input);
+    assert.equal(outcome.advance, true);
+    assert.equal(outcome.verdict, VERDICTS.verified);
+    assert.deepEqual(outcome.flags, []);
+    assert.equal(h.retries.length, 0);
+    assert.deepEqual(h.ws.outcomeFlags, [], 'clean verdict leaves no flag entry');
+
+    const rows = JSON.parse(fs.readFileSync(path.join(TASKS_DIR, '.work-actions.json'), 'utf8'));
+    const verifyRows = rows.filter((r) => r.action === 'task-verify');
+    assert.ok(verifyRows.length >= 1);
+    assert.equal(verifyRows.at(-1).allow, true);
+    assert.equal(verifyRows.at(-1).meta.verdict, VERDICTS.verified);
+  });
+
+  it('CONTRADICTED (empty boundary) blocks with retry guidance via recordRetry', () => {
+    const h = makeHarness();
+    fs.writeFileSync(path.join(TASKS_DIR, '.last-commit-sha'), git(['rev-parse', 'HEAD']));
+    const outcome = runOutcomeGate(h.input);
+    fs.writeFileSync(path.join(TASKS_DIR, '.last-commit-sha'), baseSha); // restore
+
+    assert.equal(outcome.blocked, 'retry');
+    assert.equal(h.retries.length, 1);
+    assert.match(h.retries[0].reason, /CONTRADICTED/);
+    assert.match(h.retries[0].reason, /I1/);
+    assert.deepEqual(h.retries[0].extras, {}, 'retry exit does not park a planner hold');
+  });
+
+  it('reopen-artifact exit parks the planner hold via recordRetry extras', () => {
+    const h = makeHarness();
+    const fakeBoundary = {
+      observations: { derivedTests: { files: [], runner: 'node-test' } },
+      result: {
+        verdict: VERDICTS.contradicted,
+        violatedInvariants: ['I2'],
+        flags: [],
+        exit: 'reopen-artifact',
+        reasons: ['I2: promised deliverables missing: docs/spec-entry.md'],
+      },
+    };
+    const outcome = runOutcomeGate(h.input, { observe: () => fakeBoundary });
+    assert.equal(outcome.blocked, 'reopen-artifact');
+    assert.equal(h.retries[0].extras.defectKind, 'outcome-contradiction');
+  });
+
+  it('UNVERIFIED advances and records unresolved flags on the work state', () => {
+    const h = makeHarness();
+    const fakeBoundary = {
+      observations: { derivedTests: { files: [], runner: 'none' } },
+      result: {
+        verdict: VERDICTS.unverified,
+        violatedInvariants: [],
+        flags: ['no-structured-reporter'],
+        exit: null,
+        reasons: [],
+      },
+    };
+    const outcome = runOutcomeGate(h.input, { observe: () => fakeBoundary });
+    assert.equal(outcome.advance, true);
+    assert.deepEqual(
+      h.ws.outcomeFlags.map((e) => e.task),
+      [1]
+    );
+    assert.deepEqual(h.ws.outcomeFlags[0].flags, ['no-structured-reporter']);
+    assert.ok(h.saved.length >= 1, 'flag entry persisted');
+  });
+
+  it('a re-verify that comes back clean resolves the task flag entry', () => {
+    const ws = {
+      outcomeFlags: [
+        { task: 1, flags: ['tautology'] },
+        { task: 2, flags: ['x'] },
+      ],
+    };
+    recordOutcomeFlags(ws, 1, VERDICTS.verified, []);
+    assert.deepEqual(
+      ws.outcomeFlags.map((e) => e.task),
+      [2],
+      'clean pass clears task 1'
+    );
+  });
+
+  it('verifier mechanism failure advances with a flag, never blocks', () => {
+    const h = makeHarness();
+    h.input.repoDir = path.join(ROOT, 'not-a-repo');
+    const outcome = runOutcomeGate(h.input);
+    assert.equal(outcome.advance, true);
+    assert.equal(outcome.verdict, VERDICTS.unverified);
+    assert.deepEqual(outcome.flags, ['runner-unknown']);
+    assert.equal(h.retries.length, 0);
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/boundary.js
+++ b/plugins/work/scripts/workflows/task-verify/boundary.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/**
+ * task-verify/boundary.js — shared boundary resolution for shadow (GH-755)
+ * and outcome (GH-756) modes: the task's base ref, its scope entries from
+ * the canonical task parser, and the observe+evaluate composition.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { parseTasks } = require(path.join(__dirname, '..', 'work', 'lib', 'task-parser'));
+const { mergeBase, resolveRef } = require('./collect/git-facts');
+const { buildObservations } = require('./observe');
+const { evaluate } = require('./verdict-engine');
+
+/** The task's base ref: per-task bookkeeping first, merge base as fallback. */
+function resolveTaskBaseRef(repoDir, tasksDir, env = process.env) {
+  try {
+    const sha = fs.readFileSync(path.join(tasksDir, '.last-commit-sha'), 'utf8').trim();
+    if (sha && resolveRef(repoDir, sha)) return sha;
+  } catch {
+    /* no per-task bookkeeping — fall through */
+  }
+  const base = env.BASE_BRANCH || 'main';
+  return mergeBase(repoDir, `origin/${base}`, 'HEAD') || mergeBase(repoDir, base, 'HEAD');
+}
+
+/** Scope entries for task N from the canonical parser; null when unknown. */
+function taskScopeGlobs(tasksDir, taskNum) {
+  try {
+    const tasks = parseTasks(tasksDir);
+    const task = (tasks || []).find((t) => t.num === Number(taskNum));
+    return task && Array.isArray(task.filesInScope) ? task.filesInScope : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Observe one task boundary and evaluate it.
+ * @returns {{ observations, result, baseRef } | { error: string }}
+ */
+function observeBoundary({ repoDir, tasksDir, taskNum, taskType, baseRef, baseWorktreeDir }) {
+  const resolvedBase = baseRef || resolveTaskBaseRef(repoDir, tasksDir);
+  if (!resolvedBase) {
+    return { error: 'no resolvable base ref for the task boundary' };
+  }
+  const observations = buildObservations({
+    repoDir,
+    baseRef: resolvedBase,
+    scopeGlobs: taskScopeGlobs(tasksDir, taskNum),
+    taskKind: taskType,
+    baseWorktreeDir:
+      baseWorktreeDir || path.join(tasksDir, `.task-verify-base-${path.basename(repoDir)}`),
+  });
+  return { observations, result: evaluate(observations, taskType), baseRef: resolvedBase };
+}
+
+module.exports = { resolveTaskBaseRef, taskScopeGlobs, observeBoundary };

--- a/plugins/work/scripts/workflows/task-verify/observe.js
+++ b/plugins/work/scripts/workflows/task-verify/observe.js
@@ -76,14 +76,15 @@ function buildHeadRun({ repoDir, testFiles, profile, runner, timeoutMs }) {
     };
   }
   if (testFiles.length === 0) {
+    // No test files in the task's diff is NOT the same observation as a real
+    // runner reporting 0 tests (GH-749): the task's coverage may live in
+    // untouched pre-existing tests. Absence of derived-test evidence flags
+    // (no-test-files-in-diff → UNVERIFIED); it never fabricates a "pass".
     return {
-      attempted: true,
+      attempted: false,
       supported: true,
-      outcome: 'pass',
-      testsRan: 0,
-      failures: 0,
-      exitCode: 0,
-      reporterKind: 'structured',
+      outcome: 'not-run',
+      reporterKind: 'none',
       notes: 'no test files derived from the diff',
     };
   }

--- a/plugins/work/scripts/workflows/task-verify/outcome-gate.js
+++ b/plugins/work/scripts/workflows/task-verify/outcome-gate.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * task-verify/outcome-gate.js — the OUTCOME-mode boundary gate (GH-756;
+ * plan §5.1). Active only when WORK_TDD_MODE=outcome.
+ *
+ * Task advance is decided by the verifier verdict:
+ *   VERIFIED / UNVERIFIED  → advance; flags are recorded on the work state
+ *                            (`outcomeFlags`) for task_review and the check
+ *                            step (which hard-fails on unresolved flags).
+ *   CONTRADICTED           → typed exit through the EXISTING recovery edges:
+ *                            `retry` persists the contradiction as retry
+ *                            guidance (surfaced in the next dispatch prompt);
+ *                            `reopen-artifact` parks the planner hold
+ *                            (tasks.md editable); `escalate` remains the
+ *                            operator's `work-state.js recover`.
+ *
+ * A verifier-internal failure is a MECHANISM failure: advance with a
+ * `runner-unknown` flag (absence of evidence never blocks) and an error
+ * audit row. Every boundary decision is audited (`action: task-verify`).
+ */
+
+const path = require('path');
+
+const { VERDICTS, FLAG_KINDS } = require('../lib/outcome-verdicts');
+const { observeBoundary } = require('./boundary');
+
+function appendAuditSafe(safeName, entry) {
+  try {
+    const { appendEnforcementAudit } = require(
+      path.join(__dirname, '..', 'work', 'lib', 'work-actions')
+    );
+    appendEnforcementAudit(safeName, entry);
+  } catch {
+    /* audit is best-effort */
+  }
+}
+
+/** Upsert this task's flag record on the work state (resolution = re-verify). */
+function recordOutcomeFlags(ws, taskNum, verdict, flags) {
+  const entries = Array.isArray(ws.outcomeFlags) ? ws.outcomeFlags : [];
+  const kept = entries.filter((e) => e && e.task !== taskNum);
+  if (flags.length > 0) {
+    kept.push({ task: taskNum, verdict, flags, at: new Date().toISOString() });
+  }
+  ws.outcomeFlags = kept;
+}
+
+/**
+ * Run the outcome gate for one boundary.
+ *
+ * @param {object} input - { safeName, ws, tasksDir, taskNum, taskType,
+ *   saveWorkState, recordRetry, repoDir? }
+ * @returns {{ advance: true, verdict: string, flags: string[] }
+ *         | { blocked: 'retry'|'reopen-artifact', reasons: string[] }}
+ */
+function runOutcomeGate(input, deps = {}) {
+  const { safeName, ws, tasksDir, taskNum, taskType, saveWorkState, recordRetry } = input;
+  const repoDir = input.repoDir || process.cwd();
+  const observe = deps.observe || observeBoundary;
+
+  let boundary;
+  try {
+    boundary = observe({ repoDir, tasksDir, taskNum, taskType });
+  } catch (err) {
+    boundary = { error: String(err && err.message) };
+  }
+
+  if (boundary.error) {
+    // Mechanism failure — advance with a flag, never block on it.
+    recordOutcomeFlags(ws, taskNum, VERDICTS.unverified, [FLAG_KINDS.runnerUnknown]);
+    saveWorkState(safeName, ws);
+    appendAuditSafe(safeName, {
+      origin: 'workflow',
+      task: taskNum,
+      phase: null,
+      action: 'task-verify-error',
+      allow: true,
+      reason: boundary.error.slice(0, 300),
+      outputPath: null,
+    });
+    return { advance: true, verdict: VERDICTS.unverified, flags: [FLAG_KINDS.runnerUnknown] };
+  }
+
+  const { result, observations } = boundary;
+  appendAuditSafe(safeName, {
+    origin: 'workflow',
+    task: taskNum,
+    phase: null,
+    action: 'task-verify',
+    allow: result.verdict !== VERDICTS.contradicted,
+    reason: result.verdict,
+    outputPath: null,
+    meta: {
+      kind: taskType,
+      verdict: result.verdict,
+      violatedInvariants: result.violatedInvariants,
+      flags: result.flags,
+      exit: result.exit,
+      reasons: result.reasons.slice(0, 5),
+      derivedTests: observations.derivedTests,
+    },
+  });
+
+  if (result.verdict === VERDICTS.contradicted) {
+    const reason =
+      `outcome verifier: CONTRADICTED (${result.violatedInvariants.join(', ')}) — ` +
+      result.reasons.join('; ');
+    // reopen-artifact rides the existing planner-hold edge (defectKind set);
+    // retry rides the existing retry-guidance edge (next dispatch prompt).
+    const extras = result.exit === 'reopen-artifact' ? { defectKind: 'outcome-contradiction' } : {};
+    recordRetry(reason, extras);
+    return { blocked: result.exit, reasons: result.reasons };
+  }
+
+  recordOutcomeFlags(ws, taskNum, result.verdict, result.flags);
+  saveWorkState(safeName, ws);
+  return { advance: true, verdict: result.verdict, flags: result.flags };
+}
+
+module.exports = { runOutcomeGate, recordOutcomeFlags };

--- a/plugins/work/scripts/workflows/task-verify/shadow.js
+++ b/plugins/work/scripts/workflows/task-verify/shadow.js
@@ -13,29 +13,13 @@
  * (action 'task-verify-shadow-error') and swallowed.
  */
 
-const fs = require('fs');
 const path = require('path');
 
-const { parseTasks } = require(path.join(__dirname, '..', 'work', 'lib', 'task-parser'));
-const { mergeBase, resolveRef } = require('./collect/git-facts');
-const { buildObservations } = require('./observe');
-const { evaluate } = require('./verdict-engine');
+const { observeBoundary, resolveTaskBaseRef } = require('./boundary');
 const { VERDICTS } = require('../lib/outcome-verdicts');
 
 function shadowEnabled(env = process.env) {
   return env.WORK_TDD_MODE === 'shadow';
-}
-
-/** The task's base ref: per-task bookkeeping first, merge base as fallback. */
-function resolveTaskBaseRef(repoDir, tasksDir, env = process.env) {
-  try {
-    const sha = fs.readFileSync(path.join(tasksDir, '.last-commit-sha'), 'utf8').trim();
-    if (sha && resolveRef(repoDir, sha)) return sha;
-  } catch {
-    /* no per-task bookkeeping — fall through */
-  }
-  const base = env.BASE_BRANCH || 'main';
-  return mergeBase(repoDir, `origin/${base}`, 'HEAD') || mergeBase(repoDir, base, 'HEAD');
 }
 
 /** Incumbent vs shadow: who was stricter? */
@@ -44,17 +28,6 @@ function computeDivergence(incumbent, verdict) {
   if (incumbent === 'advance' && shadowBlocks) return 'shadow-stricter';
   if (incumbent === 'blocked' && !shadowBlocks) return 'shadow-looser';
   return 'agree';
-}
-
-/** Scope entries for task N from the canonical parser; null when unknown. */
-function taskScopeGlobs(tasksDir, taskNum) {
-  try {
-    const tasks = parseTasks(tasksDir);
-    const task = (tasks || []).find((t) => t.num === taskNum);
-    return task && Array.isArray(task.filesInScope) ? task.filesInScope : null;
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -68,29 +41,27 @@ function runShadowVerification(input, deps = {}) {
     deps.appendAudit ||
     require(path.join(__dirname, '..', 'work', 'lib', 'work-actions')).appendEnforcementAudit;
 
-  const baseRef = input.baseRef || resolveTaskBaseRef(repoDir, tasksDir);
-  if (!baseRef) {
+  const boundary = observeBoundary({
+    repoDir,
+    tasksDir,
+    taskNum,
+    taskType,
+    baseRef: input.baseRef,
+    baseWorktreeDir: input.baseWorktreeDir,
+  });
+  if (boundary.error) {
     appendAudit(safeName, {
       origin: 'workflow',
       task: taskNum,
       phase: null,
       action: 'task-verify-shadow-error',
       allow: true,
-      reason: 'no resolvable base ref for the task boundary',
+      reason: boundary.error,
       outputPath: null,
     });
     return null;
   }
-
-  const observations = buildObservations({
-    repoDir,
-    baseRef,
-    scopeGlobs: taskScopeGlobs(tasksDir, taskNum),
-    taskKind: taskType,
-    baseWorktreeDir:
-      input.baseWorktreeDir || path.join(tasksDir, `.task-verify-base-${path.basename(repoDir)}`),
-  });
-  const result = evaluate(observations, taskType);
+  const { observations, result } = boundary;
 
   appendAudit(safeName, {
     origin: 'workflow',

--- a/plugins/work/scripts/workflows/task-verify/verdict-engine.js
+++ b/plugins/work/scripts/workflows/task-verify/verdict-engine.js
@@ -143,7 +143,7 @@ function evaluateCoverage(ctx) {
 
 /** Observation-mechanism flags for the head run (any kind). */
 function collectRunnerFlags(ctx) {
-  const { headRun, diff } = ctx;
+  const { headRun, diff, profile } = ctx;
   if (diff.scopeUnresolved === true) return; // scope failure is the root cause
   if (headRun.supported === false) {
     ctx.flags.add(FLAG_KINDS.runnerUnknown);
@@ -151,6 +151,18 @@ function collectRunnerFlags(ctx) {
   }
   if (headRun.attempted && headRun.reporterKind !== 'structured') {
     ctx.flags.add(FLAG_KINDS.noStructuredReporter);
+  }
+  // A test-requiring kind whose diff derived NO test files: the coverage may
+  // live in pre-existing tests, so this is absence of evidence (flag for
+  // task_review scrutiny), never a contradiction. Real 0-test RUNS (GH-749)
+  // still contradict via I4 — this branch only fires when nothing ran.
+  if (
+    profile.requiresTests &&
+    headRun.attempted === false &&
+    diff.empty !== true &&
+    !(diff.filesChanged || []).some(isTestPath)
+  ) {
+    ctx.flags.add(FLAG_KINDS.noTestFilesInDiff);
   }
 }
 

--- a/plugins/work/scripts/workflows/work-implement/__tests__/outcome-mode-hooks.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/outcome-mode-hooks.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * GH-756: in WORK_TDD_MODE=outcome the phase-scoped edit hooks stand aside —
+ * agents develop freely and the outcome verifier judges commits at the task
+ * boundary. Both enforcement hooks must exit 0 immediately in outcome mode
+ * (the GH-722 "no legal phase to author the test" deadlock class cannot
+ * exist when no phase edit-lock exists).
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawn } = require('child_process');
+const path = require('path');
+
+const ENFORCE_HOOK = path.join(__dirname, '..', 'hooks', 'work-implement-enforce.js');
+const STOP_HOOK = path.join(__dirname, '..', 'hooks', 'enforce-tdd-on-stop.js');
+
+function runHook(hookPath, stdinObj, extraEnv = {}) {
+  return new Promise((resolve) => {
+    const proc = spawn(process.execPath, [hookPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, ...extraEnv },
+    });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (d) => {
+      stdout += d;
+    });
+    proc.stderr.on('data', (d) => {
+      stderr += d;
+    });
+    proc.on('close', (code) => resolve({ code, stdout, stderr }));
+    proc.stdin.end(stdinObj ? JSON.stringify(stdinObj) : '');
+  });
+}
+
+const EDIT_PAYLOAD = {
+  tool_name: 'Edit',
+  tool_input: { file_path: '/tmp/some/source-file.js' },
+  session_id: 'test',
+};
+
+describe('outcome mode disables phase-scoped enforcement (GH-756)', () => {
+  it('work-implement-enforce exits 0 immediately in outcome mode', async () => {
+    const r = await runHook(ENFORCE_HOOK, EDIT_PAYLOAD, { WORK_TDD_MODE: 'outcome' });
+    assert.equal(r.code, 0, r.stderr);
+    assert.equal(r.stderr, '', 'no block message in outcome mode');
+  });
+
+  it('enforce-tdd-on-stop exits 0 immediately in outcome mode', async () => {
+    const r = await runHook(STOP_HOOK, { session_id: 'test' }, { WORK_TDD_MODE: 'outcome' });
+    assert.equal(r.code, 0, r.stderr);
+  });
+
+  it('process mode (default) still runs the hook body', async () => {
+    // Without a ticket/workflow context the hook allows — but it must have
+    // READ stdin (i.e. not taken the outcome-mode early exit). We can only
+    // assert exit 0 here; behavioral blocking is covered by the existing
+    // work-implement-enforce suites.
+    const r = await runHook(ENFORCE_HOOK, EDIT_PAYLOAD, { WORK_TDD_MODE: 'process' });
+    assert.equal(r.code, 0, r.stderr);
+  });
+});

--- a/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -54,6 +54,12 @@
 const fs = require('fs');
 const path = require('path');
 
+// GH-756 OUTCOME MODE: there is no phase evidence to enforce on stop — the
+// outcome verifier judges the task's commits at the boundary instead.
+if (process.env.WORK_TDD_MODE === 'outcome') {
+  process.exit(0);
+}
+
 // ─── Read stdin (SubagentStop hook data) ────────────────────────────────────
 // Prevent infinite loops: if stop_hook_active is set, another stop hook
 // is already running — exit immediately to avoid re-entrance.

--- a/plugins/work/scripts/workflows/work-implement/hooks/work-implement-enforce.js
+++ b/plugins/work/scripts/workflows/work-implement/hooks/work-implement-enforce.js
@@ -296,6 +296,13 @@ function enforceFileGate(filePath, gate) {
 }
 
 async function main() {
+  // GH-756 OUTCOME MODE: phase-scoped edit rules do not exist — agents
+  // develop freely and the outcome verifier judges the commits at the task
+  // boundary (this hook class was the root cause of the GH-722/GH-720 wedges).
+  if (process.env.WORK_TDD_MODE === 'outcome') {
+    process.exit(0);
+  }
+
   let input = '';
   for await (const chunk of process.stdin) {
     input += chunk;

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/implement-outcome-prompt.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/implement-outcome-prompt.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+/**
+ * GH-756: in outcome mode the implement dispatch prompt tells the agent to
+ * develop FREELY (no phase machine, no task-next.js) and carries the
+ * previous boundary's contradiction as ADVISORY guidance. Process mode
+ * keeps the self-paced TDD prompt unchanged.
+ */
+
+const { describe, it, before, after, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const registerImplement = require('../implement');
+
+let TASKS_DIR;
+const handlers = {};
+registerImplement((name, fn) => {
+  handlers[name] = fn;
+});
+
+const TASKS_MD = [
+  '## Task 1 — Build the thing',
+  '### Type',
+  'backend',
+  '### Files in scope',
+  '- src/**',
+  '### Dependencies',
+  'None',
+  '',
+].join('\n');
+
+before(() => {
+  TASKS_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'implement-outcome-prompt-'));
+  fs.writeFileSync(path.join(TASKS_DIR, 'tasks.md'), TASKS_MD);
+});
+after(() => {
+  fs.rmSync(TASKS_DIR, { recursive: true, force: true });
+  delete process.env.WORK_TDD_MODE;
+});
+beforeEach(() => {
+  delete process.env.WORK_TDD_MODE;
+});
+
+function enrich() {
+  const entry = { agentPrompt: '## Current Task: Task 1 — Build the thing' };
+  handlers.implement(entry, { ticket: 'TEST-1', tasksDir: TASKS_DIR });
+  return entry;
+}
+
+describe('implement dispatch prompt in outcome mode (GH-756)', () => {
+  it('outcome mode dispatches a free-implementation prompt (no phase machine)', () => {
+    process.env.WORK_TDD_MODE = 'outcome';
+    const entry = enrich();
+    assert.match(entry.agentPrompt, /outcome mode/);
+    assert.match(entry.agentPrompt, /Implement the task freely/);
+    assert.match(entry.agentPrompt, /verifier checks your COMMITS/);
+    assert.doesNotMatch(entry.agentPrompt, /task-next\.js/);
+    assert.doesNotMatch(entry.agentPrompt, /RED \/ GREEN \/ REFACTOR/);
+  });
+
+  it('injects the previous contradiction as advisory guidance on retry', () => {
+    process.env.WORK_TDD_MODE = 'outcome';
+    fs.writeFileSync(
+      path.join(TASKS_DIR, '.work-state.json'),
+      JSON.stringify({ _tddRetryReason: 'outcome verifier: CONTRADICTED (I4) — 0 tests ran' })
+    );
+    const entry = enrich();
+    assert.match(entry.agentPrompt, /Previous boundary verdict \(advisory\)/);
+    assert.match(entry.agentPrompt, /0 tests ran/);
+    fs.rmSync(path.join(TASKS_DIR, '.work-state.json'));
+  });
+
+  it('process mode (default) keeps the self-paced TDD prompt', () => {
+    const entry = enrich();
+    assert.match(entry.agentPrompt, /task-next\.js/);
+    assert.doesNotMatch(entry.agentPrompt, /outcome mode/);
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
@@ -168,6 +168,11 @@ function advanceValidatedTask(safeName, ctx, deps, currentIdx, totalTasks) {
  * Invariant: `gate.recordRetry` (the persistRetryFailure closure from
  * dispatchAdvanceGate) MUST persist the work state before returning — the
  * blocked paths below return without a saveWorkState of their own.
+ *
+ * repoDir is intentionally not passed — same cwd contract as
+ * runShadowObserver above; a wrong-cwd invocation degrades to an advance
+ * WITH a runner-unknown flag plus a task-verify-error audit row, which the
+ * check step's flag hard-fail then surfaces (never a silent wrong verdict).
  */
 function runOutcomeModeGate(safeName, ctx, deps, gate) {
   const { ws, currentIdx, totalTasks, taskNum, taskType, recordRetry } = gate;

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
@@ -157,6 +157,10 @@ function advanceValidatedTask(safeName, ctx, deps, currentIdx, totalTasks) {
  * GH-756 OUTCOME MODE: the outcome verifier decides the boundary. CONTRADICTED
  * rides the existing typed exits (retry guidance / planner hold); flags land
  * on the work state for task_review and the check step's hard-fail.
+ *
+ * Invariant: `gate.recordRetry` (the persistRetryFailure closure from
+ * dispatchAdvanceGate) MUST persist the work state before returning — the
+ * blocked paths below return without a saveWorkState of their own.
  */
 function runOutcomeModeGate(safeName, ctx, deps, gate) {
   const { ws, currentIdx, totalTasks, taskNum, taskType, recordRetry } = gate;

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
@@ -154,6 +154,33 @@ function advanceValidatedTask(safeName, ctx, deps, currentIdx, totalTasks) {
 }
 
 /**
+ * GH-756 OUTCOME MODE: the outcome verifier decides the boundary. CONTRADICTED
+ * rides the existing typed exits (retry guidance / planner hold); flags land
+ * on the work state for task_review and the check step's hard-fail.
+ */
+function runOutcomeModeGate(safeName, ctx, deps, gate) {
+  const { ws, currentIdx, totalTasks, taskNum, taskType, recordRetry } = gate;
+  const { saveWorkState } = deps;
+  const { runOutcomeGate } = require(
+    path.join(__dirname, '..', '..', '..', '..', 'task-verify', 'outcome-gate')
+  );
+  const outcome = runOutcomeGate({
+    safeName,
+    ws,
+    tasksDir: ctx && ctx.tasksDir,
+    taskNum,
+    taskType,
+    saveWorkState,
+    recordRetry,
+  });
+  if (outcome.blocked === 'reopen-artifact') return buildPlannerHoldInstruction(ws, safeName);
+  if (outcome.blocked) return null; // retry — guidance surfaces in the next dispatch
+  clearRetryState(ws);
+  saveWorkState(safeName, ws);
+  return advanceValidatedTask(safeName, ctx, deps, currentIdx, totalTasks);
+}
+
+/**
  * Load work state, reconcile tasksMeta with tasks.md, and bounds-check the
  * task pointer. Returns null when the gate has nothing to do (no tasksMeta,
  * or all tasks already done), else `{ ws, currentIdx, totalTasks, taskNum }`.
@@ -212,6 +239,19 @@ function dispatchAdvanceGate(safeName, ctx, deps) {
   const taskType = resolveTaskType(ctx.tasksDir, taskNum);
   if (taskType === 'checkpoint') {
     return advanceCheckpointTask(safeName, ctx, deps, currentIdx, totalTasks);
+  }
+
+  // GH-756 OUTCOME MODE: advance is decided by the outcome verifier verdict
+  // instead of the RED/GREEN evidence flow.
+  if (process.env.WORK_TDD_MODE === 'outcome') {
+    return runOutcomeModeGate(safeName, ctx, deps, {
+      ws,
+      currentIdx,
+      totalTasks,
+      taskNum,
+      taskType,
+      recordRetry,
+    });
   }
 
   const gateTasksBase = ctx.tasksDir ? path.dirname(ctx.tasksDir) : null;

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement.js
@@ -104,6 +104,57 @@ function buildSelfPacedPrompt(ticket, taskNum, totalTasks, taskTitle) {
 }
 
 /**
+ * GH-756 OUTCOME MODE prompt: the agent develops freely — no phases, no
+ * evidence recording, no phase-scoped edit rules. Quality is verified at the
+ * task boundary by the outcome verifier (task-verify/) over the task's
+ * actual commits. Advisory feedback: when the previous boundary was
+ * CONTRADICTED, the verifier's guidance is injected as INFORMATION.
+ */
+function buildOutcomePrompt(ticket, taskNum, totalTasks, taskTitle, tasksDir) {
+  let retryReason = null;
+  try {
+    const ws = JSON.parse(fs.readFileSync(path.join(tasksDir, '.work-state.json'), 'utf8'));
+    retryReason = ws && ws._tddRetryReason ? String(ws._tddRetryReason) : null;
+  } catch {
+    /* no state — no advisory block */
+  }
+  const lines = [
+    `## Task ${taskNum}${totalTasks ? `/${totalTasks}` : ''} — ${taskTitle}`,
+    '',
+    `Read the "## Task ${taskNum}" section of ${path.join(tasksDir, 'tasks.md')}: the`,
+    'Gherkin scenarios describe the behavior to build; Files in scope bounds',
+    'where you may work.',
+    '',
+    '### How to work (outcome mode)',
+    '- Implement the task freely: write tests and source in whatever order',
+    '  serves you; run tests locally as often as you like.',
+    '- Commit your work when done (per-task commit, ticket-tagged).',
+    '- At the task boundary a verifier checks your COMMITS: non-empty in-scope',
+    '  diff, promised files present, your tests fail on base and pass on head',
+    '  with a real test count. Tests that also pass on the base tree are',
+    '  flagged as tautologies for review — write tests that specify the NEW',
+    '  behavior.',
+    '',
+    '### Rules',
+    `- Implement ONLY Task ${taskNum} deliverables (stay in Files in scope).`,
+    '- Do NOT edit .work-state.json — it is orchestrator-managed.',
+    '- Do NOT invoke /work-implement, /work, or any other slash command.',
+  ];
+  if (retryReason) {
+    lines.push(
+      '',
+      '### Previous boundary verdict (advisory)',
+      'Your last attempt did not verify. The contradiction was:',
+      '```',
+      retryReason.slice(0, 1500),
+      '```',
+      'Address it, commit, and the boundary check will re-run.'
+    );
+  }
+  return lines.join('\n');
+}
+
+/**
  * Extract task coordinates from the buildTaskPrompt output. The
  * "## Current Task: Task N — title" header is always emitted by
  * buildTaskPrompt; the "Task N of M" context block is only present when
@@ -213,7 +264,10 @@ function enrichImplement(entry, ctx) {
     return;
   }
 
-  entry.agentPrompt = buildSelfPacedPrompt(ticket, taskNum, totalTasks, taskTitle);
+  entry.agentPrompt =
+    process.env.WORK_TDD_MODE === 'outcome'
+      ? buildOutcomePrompt(ticket, taskNum, totalTasks, taskTitle, tasksDir)
+      : buildSelfPacedPrompt(ticket, taskNum, totalTasks, taskTitle);
   entry.agentType = resolveAgentType(tasksDir, taskNum);
 }
 

--- a/plugins/work/scripts/workflows/work/steps/task-review.js
+++ b/plugins/work/scripts/workflows/work/steps/task-review.js
@@ -123,6 +123,28 @@ function computeDiffRange(reviewTasksDir, ticket) {
 }
 
 /**
+ * GH-756: surface the outcome verifier's flags for this task in the review
+ * prompt — a task that advanced UNVERIFIED (tautology suspicion, unscoped
+ * runner, ...) gets targeted scrutiny here instead of a rubber stamp.
+ */
+function outcomeFlagsNote(ctx, taskNum) {
+  try {
+    const fs = require('fs');
+    const ws = JSON.parse(fs.readFileSync(path.join(ctx.tasksDir, '.work-state.json'), 'utf8'));
+    const entry = (ws.outcomeFlags || []).find((e) => e && e.task === taskNum && !e.waived);
+    if (!entry || !entry.flags || entry.flags.length === 0) return '';
+    return (
+      ` OUTCOME FLAGS for this task: [${entry.flags.join(', ')}] — the boundary verifier ` +
+      `advanced it UNVERIFIED. Give the flagged dimension targeted scrutiny ` +
+      `(tautology → assertion quality; runner/scope flags → verify tests actually ` +
+      `exercise the change) and fail the review if it does not hold up.`
+    );
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Decision 5: intermediate task -- run parallel tests-review + code-review.
  */
 function addReviewRun(add, ctx, { currentIdx, totalTasks, currentTask }) {
@@ -153,7 +175,9 @@ function addReviewRun(add, ctx, { currentIdx, totalTasks, currentTask }) {
     `Task ${currentIdx + 1}/${totalTasks}: review "${taskTitle}" before advancing`,
     {
       agentType: 'skill',
-      agentPrompt: `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${taskTitle}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Set REPORT_FOLDER=${reviewTasksDir} for both skills. Aggregate results and fail the gate if either review fails.`,
+      agentPrompt:
+        `Run /tests-review and /code-review in parallel for task ${currentIdx + 1}/${totalTasks} ("${taskTitle}"). Scope both reviews to the task diff range${diffRange ? ` (base=${diffRange.base}, head=${diffRange.head})` : ' (computed from .last-commit-sha)'}. Set REPORT_FOLDER=${reviewTasksDir} for both skills. Aggregate results and fail the gate if either review fails.` +
+        outcomeFlagsNote(ctx, currentIdx + 1),
       diffRange,
       reportFolder: reviewTasksDir,
     }

--- a/plugins/work/scripts/workflows/work/steps/task-review.js
+++ b/plugins/work/scripts/workflows/work/steps/task-review.js
@@ -18,6 +18,7 @@
 
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const { appendAction } = require(path.join(__dirname, '..', 'lib', 'work-actions'));
 const { computeTaskDiff } = require('../gates/task-review-gate');
@@ -129,7 +130,6 @@ function computeDiffRange(reviewTasksDir, ticket) {
  */
 function outcomeFlagsNote(ctx, taskNum) {
   try {
-    const fs = require('fs');
     const ws = JSON.parse(fs.readFileSync(path.join(ctx.tasksDir, '.work-state.json'), 'utf8'));
     const entry = (ws.outcomeFlags || []).find((e) => e && e.task === taskNum && !e.waived);
     if (!entry || !entry.flags || entry.flags.length === 0) return '';


### PR DESCRIPTION
## Existing Behavior

- The implement gate always uses the RED/GREEN phase choreography (task-next.js) regardless of `WORK_TDD_MODE`.
- Phase-scoped enforcement hooks (`work-implement-enforce`, `enforce-tdd-on-stop`) always run their full edit-lock logic, which can deadlock when no legal phase exists to author a test (GH-722/GH-720 class).
- `WORK_TDD_MODE` is an undocumented value; `config-schema.js` has no entry for it.
- The check step completes without consulting outcome-verifier flags; unresolved flags from shadow mode are advisory-only with no enforcement backstop.
- `shadow.js` owns its own copies of `resolveTaskBaseRef` and `taskScopeGlobs`, duplicating boundary resolution logic.

## Intended New Behavior

- In `WORK_TDD_MODE=outcome` the implement gate's advance decision is delegated to the new `task-verify/outcome-gate.js`: VERIFIED/UNVERIFIED advance (UNVERIFIED records `outcomeFlags` on the work state); CONTRADICTED rides the existing typed exits — `retry` persists the contradiction via `_tddRetryReason` (surfaced as an advisory block in the next dispatch prompt), `reopen-artifact` parks the planner hold.
- Both phase-scoped enforcement hooks exit 0 immediately in outcome mode — the GH-722/GH-720 edit-lock deadlock class cannot exist when no phase gating is active.
- The check step hard-fails at its completion boundary on unresolved outcome flags (`check/lib/outcome-flags.js` + `outcomeFlagGate` in `check-next.js`); `task_review`'s dispatch prompt receives flagged dimensions for targeted scrutiny.
- `WORK_TDD_MODE` is formally registered in `config-schema.js` as an enum (`process | shadow | outcome`; default `process`).
- Shared boundary resolution (`resolveTaskBaseRef`, `taskScopeGlobs`, `observeBoundary`) extracted into `task-verify/boundary.js`; `shadow.js` and the new `outcome-gate.js` both import from it — no duplication.
- The free-development dispatch prompt in outcome mode (no phases, no task-next.js) is built by `buildOutcomePrompt` in `lib/step-enrichments/implement.js`.
- A verifier-internal failure is a mechanism failure: advance with a `runner-unknown` flag (absence of evidence never blocks). Every boundary decision is audited (`action: task-verify`).
- Default is unchanged (`process`); making outcome the default is gated on Phase 3 exit criteria tracked on epic GH-750.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new code
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

All paths are gated behind `WORK_TDD_MODE=outcome`; the default `process` path is untouched.

**Unit tests (16 new, 220 regression — all green):**

1. `task-verify/__tests__/outcome-gate.test.js` (6 cases) — covers VERIFIED real-repo boundary, CONTRADICTED retry/reopen-artifact typed exits, UNVERIFIED flag recording, clean re-verify resolves flag entry, mechanism failure advances with `runner-unknown`.
2. `check/__tests__/check-outcome-flags.test.js` (4 cases) — unresolved flag forces `needs_work` at completion boundary; waived/clean flags allow completion; missing state never blocks.
3. `work-implement/__tests__/outcome-mode-hooks.test.js` (3 cases) — both enforcement hooks exit 0 in outcome mode; process mode still runs hook body.
4. `work/lib/step-enrichments/__tests__/implement-outcome-prompt.test.js` (3 cases) — outcome prompt is free-development (no phase machine); previous contradiction injected as advisory; process mode prompt unchanged.

**Smoke test outcome mode end-to-end:**

```bash
WORK_TDD_MODE=outcome /work <ticket>
# Implement freely, commit, then advance the gate:
node plugins/work/scripts/workflows/work/lib/step-enrichments/implement-gate/advance-gate.js
# Expect: verifier runs, VERIFIED → task advances; or CONTRADICTED → retry guidance in next prompt
```

**Verify the check hard-fail:**

Add an unresolved entry to `.work-state.json`:
```json
{ "outcomeFlags": [{ "task": 1, "flags": ["tautology"] }] }
```
Then run the check step — expect `needs_work` with reason `unresolved outcome-verifier flags — task 1: tautology`.

**Verify hook stand-aside:**
```bash
WORK_TDD_MODE=outcome node plugins/work/scripts/workflows/work-implement/hooks/work-implement-enforce.js <<< '{}'
# exit code 0, no block message
```

Closes #756

Stacked on #761 (task-verify outcome verifier — the boundary engine this PR wires in).