### PR TITLE
feat(work): warn on plugin version skew at workflow start (GH-768)

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -72,7 +72,6 @@ plugins/work/scripts/workflows/work-spec/lib/phases/reuse_audit.js
 plugins/work/scripts/workflows/work/engine/unstick-complete.js
 plugins/work/scripts/workflows/work/lib/gherkin-task-refs.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-screenshot-validator.js
-plugins/work/scripts/workflows/work/engine/cli.js
 plugins/work/scripts/workflows/work/lib/work-actions.js
 plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
 plugins/work/scripts/workflows/work/steps/implement.js

--- a/plugins/work/scripts/workflows/work/engine/cli.js
+++ b/plugins/work/scripts/workflows/work/engine/cli.js
@@ -36,34 +36,237 @@ function buildMinimalPlanState({ ALL_STEPS, safeName, timestamp, deferredSteps }
   return ws;
 }
 
-function main(deps) {
-  const {
-    parseTicketInput,
-    inspect,
-    generatePlan,
-    transitionStep,
-    getAvailableTransitions,
-    loadActions,
-    analyzeActions,
-    loadWorkState,
-    saveWorkState,
-    appendAction,
-    requirePaths,
+/** Print an error payload as JSON and exit 1. */
+function printErrorExit(message, extra) {
+  console.log(JSON.stringify({ error: true, message, ...extra }));
+  process.exit(1);
+}
+
+/**
+ * Parse a `<TICKET>[/suffix]` CLI arg into the sanitized path-safe ticket name
+ * (shared by the transition/transitions/actions commands). Exits 1 on parse error.
+ */
+function parseSafeTicketArg(deps, input, providerCfg) {
+  const { parseTicketInput, tp } = deps;
+  let parsed;
+  try {
+    parsed = parseTicketInput(input);
+  } catch (e) {
+    printErrorExit(e.message);
+  }
+  const base = String(parsed.ticketBase).toUpperCase();
+  return tp.sanitizeTicketIdForPath(base, providerCfg) + (parsed.suffix ? '/' + parsed.suffix : '');
+}
+
+/** Parse plan args: `--rework` flag, raw ticket input, and optional suffix. */
+function parsePlanInput(parseTicketInput, rest) {
+  const rework = rest.includes('--rework');
+  let raw = rest
+    .filter((a) => a !== '--rework')
+    .join(' ')
+    .trim();
+  if (!raw) {
+    printErrorExit('Provide ticket ID or description');
+  }
+  let suffix = null;
+  try {
+    const parsed = parseTicketInput(raw);
+    raw = parsed.ticketBase;
+    suffix = parsed.suffix;
+  } catch (err) {
+    printErrorExit(err.message);
+  }
+  return { raw, suffix, rework };
+}
+
+/**
+ * Resolve the provider config: rewrite GitHub issue URLs to `#N`, and infer a
+ * default GitHub provider when a bare `#N` arrives with no configured provider.
+ */
+function resolveProviderConfig(tp, rawInput) {
+  let raw = rawInput;
+  let providerConfig = tp.getProviderConfig({ skipPrompt: true });
+  const isGitHub = providerConfig?.provider === 'github';
+
+  let ghUrlMeta = null;
+  const ghParsed = tp.parseGitHubUrl(raw);
+  if (ghParsed && (isGitHub || !providerConfig)) {
+    ghUrlMeta = ghParsed;
+    raw = '#' + ghParsed.number;
+  }
+  if (/^#\d+$/.test(raw) && !isGitHub && !providerConfig) {
+    providerConfig = { provider: 'github', projectKey: '' };
+  }
+  return { raw, providerConfig, ghUrlMeta };
+}
+
+/**
+ * Classify the normalized input as a ticket ID (Jira key, `#N` GitHub issue)
+ * or free-text description (ticket: null).
+ */
+function classifyTicket(raw, isGitHubEffective) {
+  const isJiraTicket = /^[A-Z]+-\d+$/i.test(raw);
+  const isGitHubIssue = /^#?\d+$/.test(raw) && isGitHubEffective;
+  const isGitHubPrefixed = /^GH-\d+$/i.test(raw) && isGitHubEffective;
+  const isTicket = isJiraTicket || isGitHubIssue || isGitHubPrefixed;
+  let ticket = isTicket ? raw.toUpperCase() : null;
+  if (isGitHubIssue || isGitHubPrefixed) {
+    const num = raw.replace(/^#|^GH-/i, '');
+    ticket = '#' + num;
+  }
+  return { ticket, isTicket };
+}
+
+/**
+ * Resolve the provider config and normalize the raw input into a ticket ID
+ * (Jira key, `#N` GitHub issue, or null for free-text descriptions).
+ */
+function resolveProviderAndTicket(tp, rawInput) {
+  const { raw, providerConfig, ghUrlMeta } = resolveProviderConfig(tp, rawInput);
+  const isGitHubEffective = providerConfig?.provider === 'github';
+  const { ticket, isTicket } = classifyTicket(raw, isGitHubEffective);
+  if (ghUrlMeta && isGitHubEffective) {
+    providerConfig.owner = ghUrlMeta.owner;
+    providerConfig.repo = ghUrlMeta.repo;
+  }
+  return { raw, providerConfig, ghUrlMeta, ticket, isTicket };
+}
+
+/** Persist DEFER metadata into work state for transition guard (GH-154). */
+function persistDeferMetadata(deps, { ticket, suffix, providerConfig, result }) {
+  const { tp, loadWorkState, saveWorkState, appendAction, ALL_STEPS, STEPS } = deps;
+  if (!ticket) return;
+  const safeBase = tp.sanitizeTicketIdForPath(ticket, providerConfig);
+  const safeName = suffix ? safeBase + '/' + suffix : safeBase;
+  const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
+  const planState = loadWorkState(safeName);
+  if (planState) {
+    planState.lastPlanTimestamp = result.timestamp;
+    planState.deferredSteps = deferSteps;
+    saveWorkState(safeName, planState);
+  } else if (deferSteps.length > 0) {
+    const minimalState = buildMinimalPlanState({
+      ALL_STEPS,
+      safeName,
+      timestamp: result.timestamp,
+      deferredSteps: deferSteps,
+    });
+    saveWorkState(safeName, minimalState);
+    appendAction(safeName, { step: STEPS.ticket, what: 'workflow started' });
+  }
+}
+
+/** Compact state view attached to the plan output when inspect() ran. */
+function buildPlanStateView(state) {
+  return {
+    worktreeExists: state.worktreeExists,
+    branch: state.branch,
+    headSha: state.headSha?.substring(0, 8) || null,
+    hasDiffVsMain: state.hasDiffVsMain,
+    diffSummary: state.diffSummary,
+    lastCommitMsg: state.lastCommitMsg,
+    hasUncommitted: state.hasUncommitted,
+    uncommittedCount: state.uncommittedCount,
+    hasUnpushed: state.hasUnpushed,
+    pr: state.pr ? { number: state.pr.number, isDraft: state.pr.isDraft } : null,
+    reports: state.reports,
+    allReportsPass: state.allReportsPass,
+    missingReports: state.missingReports,
+    failedReports: state.failedReports,
+    prEverUpdated: state.prEverUpdated,
+    prShaMatch: state.prShaMatch,
+    hasDevSession: state.hasDevSession,
+    workStateStatus: state.workState?.status || null,
+  };
+}
+
+/** Attach aggregate action counts over the generated plan. */
+function attachPlanSummary(result) {
+  const by = (a) => result.plan.filter((s) => s.action === a);
+  result.summary = {
+    total: result.plan.length,
+    run: by('RUN').length,
+    defer: by('DEFER').length,
+    pending: by('PENDING').length,
+    firstAction: by('RUN')[0]?.step || by('DEFER')[0]?.step || 'none',
+    stepsToRun: by('RUN').map((s) => s.step),
+    stepsDeferred: by('DEFER').map((s) => s.step),
+  };
+}
+
+function runPlanCommand(deps, rest) {
+  const { parseTicketInput, inspect, generatePlan, tp, STEP_TRANSITIONS } = deps;
+  const { raw: parsedRaw, suffix, rework } = parsePlanInput(parseTicketInput, rest);
+  const { raw, providerConfig, ghUrlMeta, ticket, isTicket } = resolveProviderAndTicket(
     tp,
-    STEPS,
-    ALL_STEPS,
-    STEP_TRANSITIONS,
-  } = deps;
+    parsedRaw
+  );
+  const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
+  let result;
+  try {
+    result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
+  } catch (err) {
+    printErrorExit(err?.message || String(err));
+  }
+
+  result.timestamp = new Date().toISOString();
+  persistDeferMetadata(deps, { ticket, suffix, providerConfig, result });
+
+  if (ghUrlMeta && providerConfig) {
+    result.ticketUrl = tp.ticketUrl(ticket, providerConfig);
+  }
+  if (state) {
+    result.currentStep = state.currentStep;
+    result.allowedTransitions = STEP_TRANSITIONS[state.currentStep] || [];
+    result.state = buildPlanStateView(state);
+  }
+  attachPlanSummary(result);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+function runTransitionCommand(deps, rest) {
+  const { tp, transitionStep, ALL_STEPS } = deps;
+  if (rest.length < 2) {
+    printErrorExit('Usage: transition <TICKET> <step>', { validSteps: ALL_STEPS });
+  }
+  const transProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+  const safeTransTicket = parseSafeTicketArg(deps, rest[0], transProviderCfg);
+  console.log(JSON.stringify(transitionStep(safeTransTicket, rest[1]), null, 2));
+}
+
+function runTransitionsCommand(deps, rest) {
+  const { tp, getAvailableTransitions } = deps;
+  if (!rest[0]) {
+    printErrorExit('Usage: transitions <TICKET>');
+  }
+  const transitionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+  const safeTransitionsTicket = parseSafeTicketArg(deps, rest[0], transitionsProviderCfg);
+  console.log(JSON.stringify(getAvailableTransitions(safeTransitionsTicket), null, 2));
+}
+
+function runActionsCommand(deps, rest) {
+  const { tp, loadActions, analyzeActions } = deps;
+  if (!rest[0]) {
+    printErrorExit('Usage: actions <TICKET> [--raw]');
+  }
+  const actionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
+  const ticket = parseSafeTicketArg(deps, rest[0], actionsProviderCfg);
+  const raw = rest.includes('--raw');
+  const actions = loadActions(ticket);
+  if (raw) {
+    console.log(JSON.stringify({ ticket, actions }, null, 2));
+  } else {
+    const analysis = analyzeActions(actions);
+    console.log(JSON.stringify({ ticket, analysis, actions }, null, 2));
+  }
+}
+
+function main(deps) {
+  const { requirePaths, ALL_STEPS, STEP_TRANSITIONS } = deps;
 
   const args = process.argv.slice(2);
   if (args.length === 0) {
-    console.log(
-      JSON.stringify({
-        error: true,
-        message: 'Usage: work-orchestrator.js [plan|transition|transitions|graph] <args>',
-      })
-    );
-    process.exit(1);
+    printErrorExit('Usage: work-orchestrator.js [plan|transition|transitions|graph] <args>');
   }
 
   const subcommands = ['plan', 'transition', 'transitions', 'graph', 'actions'];
@@ -73,211 +276,26 @@ function main(deps) {
   switch (command) {
     case 'plan': {
       requirePaths();
-      const rework = rest.includes('--rework');
-      let raw = rest
-        .filter((a) => a !== '--rework')
-        .join(' ')
-        .trim();
-      if (!raw) {
-        console.log(JSON.stringify({ error: true, message: 'Provide ticket ID or description' }));
-        process.exit(1);
-      }
-
-      let suffix = null;
-      try {
-        const parsed = parseTicketInput(raw);
-        raw = parsed.ticketBase;
-        suffix = parsed.suffix;
-      } catch (err) {
-        console.log(JSON.stringify({ error: true, message: err.message }));
-        process.exit(1);
-      }
-
-      let providerConfig = tp.getProviderConfig({ skipPrompt: true });
-      const isGitHub = providerConfig?.provider === 'github';
-
-      let ghUrlMeta = null;
-      const ghParsed = tp.parseGitHubUrl(raw);
-      if (ghParsed && (isGitHub || !providerConfig)) {
-        ghUrlMeta = ghParsed;
-        raw = '#' + ghParsed.number;
-      }
-      if (/^#\d+$/.test(raw) && !isGitHub && !providerConfig) {
-        providerConfig = { provider: 'github', projectKey: '' };
-      }
-      const isGitHubEffective = providerConfig?.provider === 'github';
-      const isJiraTicket = /^[A-Z]+-\d+$/i.test(raw);
-      const isGitHubIssue = /^#?\d+$/.test(raw) && isGitHubEffective;
-      const isGitHubPrefixed = /^GH-\d+$/i.test(raw) && isGitHubEffective;
-      const isTicket = isJiraTicket || isGitHubIssue || isGitHubPrefixed;
-      let ticket = isTicket ? raw.toUpperCase() : null;
-      if ((isGitHubIssue || isGitHubPrefixed) && isGitHubEffective) {
-        const num = raw.replace(/^#|^GH-/i, '');
-        ticket = '#' + num;
-      }
-      if (ghUrlMeta && isGitHubEffective) {
-        providerConfig.owner = ghUrlMeta.owner;
-        providerConfig.repo = ghUrlMeta.repo;
-      }
-      const state = ticket ? inspect(ticket, providerConfig, suffix) : null;
-      let result;
-      try {
-        result = generatePlan(ticket, isTicket ? null : raw, state, rework, providerConfig, suffix);
-      } catch (err) {
-        console.log(JSON.stringify({ error: true, message: err?.message || String(err) }));
-        process.exit(1);
-      }
-
-      result.timestamp = new Date().toISOString();
-
-      // Persist DEFER metadata into work state for transition guard (GH-154)
-      if (ticket) {
-        const safeBase_plan = tp.sanitizeTicketIdForPath(ticket, providerConfig);
-        const safeName_plan = suffix ? safeBase_plan + '/' + suffix : safeBase_plan;
-        const planState = loadWorkState(safeName_plan);
-        if (planState) {
-          planState.lastPlanTimestamp = result.timestamp;
-          planState.deferredSteps = result.plan
-            .filter((s) => s.action === 'DEFER')
-            .map((s) => s.step);
-          saveWorkState(safeName_plan, planState);
-        } else {
-          const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
-          if (deferSteps.length > 0) {
-            const minimalState = buildMinimalPlanState({
-              ALL_STEPS,
-              safeName: safeName_plan,
-              timestamp: result.timestamp,
-              deferredSteps: deferSteps,
-            });
-            saveWorkState(safeName_plan, minimalState);
-            appendAction(safeName_plan, { step: STEPS.ticket, what: 'workflow started' });
-          }
-        }
-      }
-
-      if (ghUrlMeta && providerConfig) {
-        result.ticketUrl = tp.ticketUrl(ticket, providerConfig);
-      }
-      if (state) {
-        result.currentStep = state.currentStep;
-        result.allowedTransitions = STEP_TRANSITIONS[state.currentStep] || [];
-        result.state = {
-          worktreeExists: state.worktreeExists,
-          branch: state.branch,
-          headSha: state.headSha?.substring(0, 8) || null,
-          hasDiffVsMain: state.hasDiffVsMain,
-          diffSummary: state.diffSummary,
-          lastCommitMsg: state.lastCommitMsg,
-          hasUncommitted: state.hasUncommitted,
-          uncommittedCount: state.uncommittedCount,
-          hasUnpushed: state.hasUnpushed,
-          pr: state.pr ? { number: state.pr.number, isDraft: state.pr.isDraft } : null,
-          reports: state.reports,
-          allReportsPass: state.allReportsPass,
-          missingReports: state.missingReports,
-          failedReports: state.failedReports,
-          prEverUpdated: state.prEverUpdated,
-          prShaMatch: state.prShaMatch,
-          hasDevSession: state.hasDevSession,
-          workStateStatus: state.workState?.status || null,
-        };
-      }
-      const by = (a) => result.plan.filter((s) => s.action === a);
-      result.summary = {
-        total: result.plan.length,
-        run: by('RUN').length,
-        defer: by('DEFER').length,
-        pending: by('PENDING').length,
-        firstAction: by('RUN')[0]?.step || by('DEFER')[0]?.step || 'none',
-        stepsToRun: by('RUN').map((s) => s.step),
-        stepsDeferred: by('DEFER').map((s) => s.step),
-      };
-      console.log(JSON.stringify(result, null, 2));
+      runPlanCommand(deps, rest);
       break;
     }
-
     case 'transition': {
       requirePaths();
-      if (rest.length < 2) {
-        console.log(
-          JSON.stringify({
-            error: true,
-            message: 'Usage: transition <TICKET> <step>',
-            validSteps: ALL_STEPS,
-          })
-        );
-        process.exit(1);
-      }
-      const transProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let transParsed;
-      try {
-        transParsed = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const transBase = String(transParsed.ticketBase).toUpperCase();
-      const safeTransTicket =
-        tp.sanitizeTicketIdForPath(transBase, transProviderCfg) +
-        (transParsed.suffix ? '/' + transParsed.suffix : '');
-      console.log(JSON.stringify(transitionStep(safeTransTicket, rest[1]), null, 2));
+      runTransitionCommand(deps, rest);
       break;
     }
-
     case 'transitions': {
       requirePaths();
-      if (!rest[0]) {
-        console.log(JSON.stringify({ error: true, message: 'Usage: transitions <TICKET>' }));
-        process.exit(1);
-      }
-      const transitionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let transParsed2;
-      try {
-        transParsed2 = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const transBase2 = String(transParsed2.ticketBase).toUpperCase();
-      const safeTransitionsTicket =
-        tp.sanitizeTicketIdForPath(transBase2, transitionsProviderCfg) +
-        (transParsed2.suffix ? '/' + transParsed2.suffix : '');
-      console.log(JSON.stringify(getAvailableTransitions(safeTransitionsTicket), null, 2));
+      runTransitionsCommand(deps, rest);
       break;
     }
-
     case 'graph': {
       console.log(JSON.stringify({ steps: ALL_STEPS, transitions: STEP_TRANSITIONS }, null, 2));
       break;
     }
-
     case 'actions': {
       requirePaths();
-      if (!rest[0]) {
-        console.log(JSON.stringify({ error: true, message: 'Usage: actions <TICKET> [--raw]' }));
-        process.exit(1);
-      }
-      const actionsProviderCfg = tp.getProviderConfig({ skipPrompt: true });
-      let actionsParsed;
-      try {
-        actionsParsed = parseTicketInput(rest[0]);
-      } catch (e) {
-        console.log(JSON.stringify({ error: true, message: e.message }));
-        process.exit(1);
-      }
-      const actionsBase = String(actionsParsed.ticketBase).toUpperCase();
-      const ticket =
-        tp.sanitizeTicketIdForPath(actionsBase, actionsProviderCfg) +
-        (actionsParsed.suffix ? '/' + actionsParsed.suffix : '');
-      const raw = rest.includes('--raw');
-      const actions = loadActions(ticket);
-      if (raw) {
-        console.log(JSON.stringify({ ticket, actions }, null, 2));
-      } else {
-        const analysis = analyzeActions(actions);
-        console.log(JSON.stringify({ ticket, analysis, actions }, null, 2));
-      }
+      runActionsCommand(deps, rest);
       break;
     }
   }

--- a/plugins/work/scripts/workflows/work/engine/cli.js
+++ b/plugins/work/scripts/workflows/work/engine/cli.js
@@ -9,6 +9,33 @@
  * are injected via `deps` for testability and to avoid circular imports.
  */
 
+const { stampVersionAnchor } = require('../lib/version-skew');
+
+/**
+ * Minimal fresh defer-state for the plan path when no work state exists yet
+ * (GH-154). Extracted from the former inline `minimalState` literal so the
+ * shape is directly assertable; carries the version anchor from birth (GH-768).
+ */
+function buildMinimalPlanState({ ALL_STEPS, safeName, timestamp, deferredSteps }) {
+  const ws = {
+    ticketId: safeName,
+    description: '',
+    currentStep: 1,
+    status: 'in_progress',
+    stepStatus: {},
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    lastPlanTimestamp: timestamp,
+    deferredSteps,
+  };
+  ALL_STEPS.forEach((s) => {
+    ws.stepStatus[s] = 'pending';
+  });
+  stampVersionAnchor(ws);
+  return ws;
+}
+
 function main(deps) {
   const {
     parseTicketInput,
@@ -117,20 +144,11 @@ function main(deps) {
         } else {
           const deferSteps = result.plan.filter((s) => s.action === 'DEFER').map((s) => s.step);
           if (deferSteps.length > 0) {
-            const minimalState = {
-              ticketId: safeName_plan,
-              description: '',
-              currentStep: 1,
-              status: 'in_progress',
-              stepStatus: {},
-              checkProgress: {},
-              errors: [],
-              startTime: new Date().toISOString(),
-              lastPlanTimestamp: result.timestamp,
+            const minimalState = buildMinimalPlanState({
+              ALL_STEPS,
+              safeName: safeName_plan,
+              timestamp: result.timestamp,
               deferredSteps: deferSteps,
-            };
-            ALL_STEPS.forEach((s) => {
-              minimalState.stepStatus[s] = 'pending';
             });
             saveWorkState(safeName_plan, minimalState);
             appendAction(safeName_plan, { step: STEPS.ticket, what: 'workflow started' });
@@ -265,4 +283,4 @@ function main(deps) {
   }
 }
 
-module.exports = { main };
+module.exports = { main, buildMinimalPlanState };

--- a/plugins/work/scripts/workflows/work/engine/transition-step.js
+++ b/plugins/work/scripts/workflows/work/engine/transition-step.js
@@ -17,6 +17,7 @@ const { computeTaskNum, runTransitionGates, cleanStaleTddEvidence } = require(
   path.join(__dirname, 'transition-gates')
 );
 const { computeGateInputHashes } = require(path.join(__dirname, '..', 'lib', 'gate-input-hashes'));
+const { stampVersionAnchor } = require(path.join(__dirname, '..', 'lib', 'version-skew'));
 
 /** Fresh work state for a first-ever transition. */
 function initialTransitionState(deps, safeTicket) {
@@ -31,6 +32,7 @@ function initialTransitionState(deps, safeTicket) {
     startTime: new Date().toISOString(),
     lastUpdate: new Date().toISOString(),
   };
+  stampVersionAnchor(ws);
   deps.ALL_STEPS.forEach((s) => {
     ws.stepStatus[s] = 'pending';
   });
@@ -219,4 +221,4 @@ function getAvailableTransitions(ticket, deps) {
   };
 }
 
-module.exports = { transitionStep, getAvailableTransitions };
+module.exports = { transitionStep, getAvailableTransitions, initialTransitionState };

--- a/plugins/work/scripts/workflows/work/lib/__tests__/next-instruction-version-skew.e2e.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/next-instruction-version-skew.e2e.test.js
@@ -1,0 +1,296 @@
+'use strict';
+
+/**
+ * E2E tests for GH-768 Task 3 — wiring `checkVersionSkew` into workflow start
+ * in `createGetNextInstruction` (lib/next-instruction.js).
+ *
+ * Drives the REAL `createGetNextInstruction` closure with an injected env over
+ * a `fs.mkdtempSync` temp TASKS_BASE. The executing version is the real
+ * installed plugin version (read via the same `readInstalledVersion` seam the
+ * wiring must use); skew is created by writing a different-but-valid
+ * `pluginVersionAnchor` into the temp `.work-state.json`.
+ *
+ * Scenarios (gherkin titles verbatim):
+ *   - Skewed version emits a banner warning and an audit row
+ *   - Matching versions stay silent
+ *   - Pre-feature ticket without an anchor degrades gracefully
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { createGetNextInstruction } = require('../next-instruction');
+const { readInstalledVersion } = require('../update-check');
+const { ALL_STEPS, STEP_TRANSITIONS, STEPS } = require('../../step-registry');
+
+const TICKET = 'ECHO-1';
+const EXECUTING_VERSION = readInstalledVersion();
+// A valid X.Y.Z that can never equal the real installed version.
+const SKEWED_ANCHOR = '0.0.1';
+
+assert.ok(
+  /^\d+\.\d+\.\d+$/.test(EXECUTING_VERSION || ''),
+  `test precondition: installed plugin version must be readable, got: ${EXECUTING_VERSION}`
+);
+
+// ─── Fixture helpers ────────────────────────────────────────────────────────
+
+function statePathFor(tasksBase, safeName) {
+  return path.join(tasksBase, safeName, '.work-state.json');
+}
+
+function writeStateFile(tasksBase, safeName, extraFields = {}) {
+  const dir = path.join(tasksBase, safeName);
+  fs.mkdirSync(dir, { recursive: true });
+  const state = {
+    ticketId: safeName,
+    ticketBase: safeName,
+    ticketSuffix: null,
+    ticketSeparator: null,
+    description: 'version-skew e2e fixture',
+    currentStep: 8,
+    status: 'in_progress',
+    stepStatus: Object.fromEntries(ALL_STEPS.map((s) => [s, 'pending'])),
+    checkProgress: {},
+    errors: [],
+    startTime: new Date().toISOString(),
+    ...extraFields,
+  };
+  fs.writeFileSync(statePathFor(tasksBase, safeName), JSON.stringify(state, null, 2));
+  return state;
+}
+
+function readStateFile(tasksBase, safeName) {
+  return JSON.parse(fs.readFileSync(statePathFor(tasksBase, safeName), 'utf8'));
+}
+
+/** Stub workDir whose work-state.js exits 0 (handleAdvanceTask succeeds). */
+function makeStubWorkDir(tmpRoot) {
+  const dir = path.join(tmpRoot, 'stub-work-dir');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'work-state.js'), 'process.exit(0);\n');
+  return dir;
+}
+
+/**
+ * Build the injected orchestrator env. Real FS-backed load/save over the temp
+ * TASKS_BASE (with recording), recording appendAction, inert provider stubs,
+ * and an empty plan so the loop falls through to the `complete` instruction
+ * without touching gates/enrichments.
+ */
+function buildEnv(tasksBase, overrides = {}) {
+  const auditRows = [];
+  const savedStates = [];
+  const generatePlanResults = overrides.generatePlanResults || null;
+  let planCalls = 0;
+
+  const env = {
+    tp: {
+      getProviderConfig: () => ({ provider: 'jira' }),
+      sanitizeTicketIdForPath: (t) => t,
+    },
+    validateRawTicketInput: (raw) => ({ ticketBase: raw, suffix: null, separator: null }),
+    inspect: () => null,
+    generatePlan: () => {
+      planCalls++;
+      if (generatePlanResults) {
+        const idx = Math.min(planCalls - 1, generatePlanResults.length - 1);
+        // shallow copy — persistPlanMetadata mutates the result object
+        return { ...generatePlanResults[idx] };
+      }
+      return { plan: [] };
+    },
+    loadWorkState: (safeName) => {
+      try {
+        return JSON.parse(fs.readFileSync(statePathFor(tasksBase, safeName), 'utf8'));
+      } catch {
+        return null;
+      }
+    },
+    saveWorkState: (safeName, ws) => {
+      savedStates.push(JSON.parse(JSON.stringify(ws)));
+      fs.writeFileSync(statePathFor(tasksBase, safeName), JSON.stringify(ws, null, 2));
+    },
+    appendAction: (safeName, row) => {
+      auditRows.push({ safeName, ...row });
+    },
+    transitionStep: () => ({ error: true, message: 'not under test' }),
+    getCurrentStep: () => 'implement',
+    ALL_STEPS,
+    STEP_TRANSITIONS,
+    STEPS,
+    TASKS_BASE: tasksBase,
+    WORKTREES_BASE: path.join(tasksBase, 'no-worktrees'),
+    MAIN_WORKTREE_FOLDER: 'no-such-repo',
+    workDir: makeStubWorkDir(tasksBase),
+    work2Dir: tasksBase,
+    ...overrides.env,
+  };
+  return { env, auditRows, savedStates };
+}
+
+function skewRows(auditRows) {
+  return auditRows.filter((r) => r.what === 'plugin version skew detected');
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('next-instruction version-skew wiring (GH-768 Task 3)', () => {
+  let tasksBase;
+  let prevSessionGuard;
+
+  beforeEach(() => {
+    tasksBase = fs.mkdtempSync(path.join(os.tmpdir(), 'next-instr-skew-'));
+    prevSessionGuard = process.env.SESSION_GUARD_ENABLED;
+    process.env.SESSION_GUARD_ENABLED = '0';
+  });
+
+  afterEach(() => {
+    fs.rmSync(tasksBase, { recursive: true, force: true });
+    if (prevSessionGuard === undefined) delete process.env.SESSION_GUARD_ENABLED;
+    else process.env.SESSION_GUARD_ENABLED = prevSessionGuard;
+  });
+
+  it('Skewed version emits a banner warning and an audit row', () => {
+    writeStateFile(tasksBase, TICKET, { pluginVersionAnchor: SKEWED_ANCHOR });
+    const { env, auditRows } = buildEnv(tasksBase);
+    const getNextInstruction = createGetNextInstruction(env);
+
+    const instr = getNextInstruction(TICKET);
+
+    // Never a block: the workflow still returns its normal next instruction.
+    assert.ok(instr, 'expected an instruction object');
+    assert.notEqual(
+      instr.action,
+      'blocked',
+      `skew must never block the workflow, got: ${JSON.stringify(instr)}`
+    );
+
+    // Banner surfaces in the instruction's state block (stateCtx.versionSkew).
+    const banner = instr.state && instr.state.versionSkew;
+    assert.equal(typeof banner, 'string', 'expected state.versionSkew banner string');
+    assert.ok(
+      banner.includes(EXECUTING_VERSION),
+      `banner must name the executing version ${EXECUTING_VERSION}; got: ${banner}`
+    );
+    assert.ok(
+      banner.includes(SKEWED_ANCHOR),
+      `banner must name the recorded version ${SKEWED_ANCHOR}; got: ${banner}`
+    );
+    assert.ok(
+      banner.includes(statePathFor(tasksBase, TICKET)),
+      `banner must name the state file path; got: ${banner}`
+    );
+
+    // Exactly one audit row with the exact contract shape.
+    const rows = skewRows(auditRows);
+    assert.equal(rows.length, 1, `expected exactly one skew audit row, got ${rows.length}`);
+    assert.equal(rows[0].meta.executingVersion, EXECUTING_VERSION);
+    assert.equal(rows[0].meta.recordedVersion, SKEWED_ANCHOR);
+    assert.equal(rows[0].meta.stateFile, statePathFor(tasksBase, TICKET));
+
+    // Anchor is never re-baselined on warn.
+    assert.equal(readStateFile(tasksBase, TICKET).pluginVersionAnchor, SKEWED_ANCHOR);
+  });
+
+  it('runs the skew check only once per top-level invocation (auto-advance recursion)', () => {
+    writeStateFile(tasksBase, TICKET, { pluginVersionAnchor: SKEWED_ANCHOR });
+    // saveWorkState recorder that does NOT persist: the de-dup marker never
+    // reaches disk, so if the check re-ran on the recursed pass it would
+    // append a SECOND audit row. The recursionDepth===1 guard prevents that.
+    const savedOnly = [];
+    const { env, auditRows } = buildEnv(tasksBase, {
+      generatePlanResults: [{ plan: [], nextAction: 'advance_task' }, { plan: [] }],
+      env: {
+        saveWorkState: (_safeName, ws) => {
+          savedOnly.push(JSON.parse(JSON.stringify(ws)));
+        },
+      },
+    });
+    const getNextInstruction = createGetNextInstruction(env);
+
+    const instr = getNextInstruction(TICKET);
+
+    assert.ok(instr, 'expected an instruction object');
+    assert.notEqual(instr.action, 'blocked', 'auto-advance run must not be blocked');
+    const rows = skewRows(auditRows);
+    assert.equal(
+      rows.length,
+      1,
+      `skew check must run once per top-level invocation — expected 1 audit row across the recursed passes, got ${rows.length}`
+    );
+  });
+
+  it('Matching versions stay silent', () => {
+    writeStateFile(tasksBase, TICKET, {
+      pluginVersionAnchor: EXECUTING_VERSION,
+      pluginVersionAnchorAt: '2026-01-01T00:00:00.000Z',
+    });
+    const { env, auditRows, savedStates } = buildEnv(tasksBase);
+    const getNextInstruction = createGetNextInstruction(env);
+
+    const instr = getNextInstruction(TICKET);
+
+    assert.ok(instr, 'expected an instruction object');
+    assert.notEqual(instr.action, 'blocked');
+    assert.ok(
+      !instr.state || !('versionSkew' in instr.state),
+      `matching versions must not attach a versionSkew field; got: ${JSON.stringify(instr.state)}`
+    );
+    assert.equal(skewRows(auditRows).length, 0, 'no audit row on match');
+
+    // No skew-driven state rewrite: nothing saved ever carries the de-dup
+    // marker and the anchor fields on disk are untouched.
+    for (const saved of savedStates) {
+      assert.ok(!('versionSkewWarnedFor' in saved), 'match must not write versionSkewWarnedFor');
+    }
+    const after = readStateFile(tasksBase, TICKET);
+    assert.equal(after.pluginVersionAnchor, EXECUTING_VERSION);
+    assert.equal(after.pluginVersionAnchorAt, '2026-01-01T00:00:00.000Z');
+    assert.ok(!('versionSkewWarnedFor' in after), 'no de-dup marker persisted on match');
+  });
+
+  it('Pre-feature ticket without an anchor degrades gracefully', () => {
+    const before = writeStateFile(tasksBase, TICKET); // no anchor fields at all
+    assert.ok(!('pluginVersionAnchor' in before), 'fixture precondition: pre-feature state');
+    const { env, auditRows } = buildEnv(tasksBase);
+    const getNextInstruction = createGetNextInstruction(env);
+
+    const instr = getNextInstruction(TICKET);
+
+    // Silent adoption: no banner, no false warning, no skew audit row.
+    assert.ok(instr, 'expected an instruction object');
+    assert.notEqual(instr.action, 'blocked');
+    assert.ok(
+      !instr.state || !('versionSkew' in instr.state),
+      `adoption must be silent; got: ${JSON.stringify(instr.state)}`
+    );
+    assert.equal(skewRows(auditRows).length, 0, 'no skew audit row on adoption');
+
+    // The anchor is persisted to disk through the env's real saveWorkState.
+    const after = readStateFile(tasksBase, TICKET);
+    assert.equal(
+      after.pluginVersionAnchor,
+      EXECUTING_VERSION,
+      'adopt path must persist the executing version as the anchor'
+    );
+    assert.ok(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(after.pluginVersionAnchorAt || ''),
+      `expected ISO pluginVersionAnchorAt, got: ${after.pluginVersionAnchorAt}`
+    );
+    assert.ok(!('versionSkewWarnedFor' in after), 'adoption must not set the de-dup marker');
+
+    // Additive-only write: every pre-existing field survives unchanged.
+    for (const key of Object.keys(before)) {
+      if (key === 'lastPlanTimestamp' || key === 'deferredSteps') continue; // plan metadata refresh
+      assert.deepEqual(
+        after[key],
+        before[key],
+        `pre-existing field "${key}" must be preserved by the adoption write`
+      );
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/version-anchor-creation.e2e.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/version-anchor-creation.e2e.test.js
@@ -1,0 +1,197 @@
+/**
+ * version-anchor-creation.e2e.test.js — GH-768 Task 2
+ *
+ * Scenario: New ticket records a version anchor at state creation
+ *
+ * Drives the four real fresh-state constructors and asserts every one stamps
+ * `pluginVersionAnchor` (= the executing plugin version) plus an ISO
+ * `pluginVersionAnchorAt` timestamp at creation:
+ *   1. `initialTransitionState`  (engine/transition-step.js — test-only export)
+ *   2. `buildInitialDeferState`  (lib/next-preflight.js — test-only export)
+ *   3. `buildMinimalPlanState`   (engine/cli.js — extracted from the inline
+ *                                 `minimalState` literal)
+ *   4. `initState`               (work-state/core.js — exercised against a
+ *                                 fs.mkdtempSync temp TASKS_BASE)
+ *
+ * Uses node:test + node:assert/strict with direct `require()` (the
+ * work-claims.test.js convention: TASKS_BASE is pinned to a temp dir BEFORE
+ * requiring config-reading modules, since config.js resolves it once at
+ * require time).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Pin TASKS_BASE to a temp dir BEFORE requiring work-state/core (config.js
+// resolves TASKS_BASE once at require() time).
+const TEMP_TASKS_BASE = fs.mkdtempSync(path.join(os.tmpdir(), 'version-anchor-test-'));
+const ORIGINAL_TASKS_BASE = process.env.TASKS_BASE;
+process.env.TASKS_BASE = TEMP_TASKS_BASE;
+
+// Clear cached modules that read TASKS_BASE at require time so the override
+// takes effect even if another test file loaded them first in this process.
+for (const key of Object.keys(require.cache)) {
+  if (key.includes(path.join('workflows', 'lib', 'config.js'))) delete require.cache[key];
+  if (key.includes(path.join('work', 'work-state'))) delete require.cache[key];
+}
+
+const { describe, it, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { readInstalledVersion } = require(path.join(__dirname, '..', 'update-check'));
+const transitionStepMod = require(path.join(__dirname, '..', '..', 'engine', 'transition-step'));
+const nextPreflightMod = require(path.join(__dirname, '..', 'next-preflight'));
+const cliMod = require(path.join(__dirname, '..', '..', 'engine', 'cli'));
+const workStateCore = require(path.join(__dirname, '..', '..', 'work-state', 'core'));
+
+const EXECUTING_VERSION = readInstalledVersion();
+const ISO_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+const FAKE_ALL_STEPS = ['ticket', 'bootstrap', 'implement', 'complete'];
+const FAKE_STEPS = { ticket: 'ticket' };
+
+function assertAnchor(ws, label) {
+  assert.equal(
+    ws.pluginVersionAnchor,
+    EXECUTING_VERSION,
+    `${label}: pluginVersionAnchor must equal the executing plugin version`
+  );
+  assert.equal(typeof ws.pluginVersionAnchorAt, 'string', `${label}: pluginVersionAnchorAt type`);
+  assert.match(
+    ws.pluginVersionAnchorAt,
+    ISO_RE,
+    `${label}: pluginVersionAnchorAt must be an ISO timestamp`
+  );
+}
+
+describe('New ticket records a version anchor at state creation', () => {
+  after(() => {
+    if (ORIGINAL_TASKS_BASE === undefined) {
+      delete process.env.TASKS_BASE;
+    } else {
+      process.env.TASKS_BASE = ORIGINAL_TASKS_BASE;
+    }
+    fs.rmSync(TEMP_TASKS_BASE, { recursive: true, force: true });
+  });
+
+  it('initialTransitionState stamps the anchor on the fresh transition state', () => {
+    assert.equal(
+      typeof transitionStepMod.initialTransitionState,
+      'function',
+      'engine/transition-step.js must export initialTransitionState for direct assertion'
+    );
+    const actions = [];
+    const deps = {
+      ALL_STEPS: FAKE_ALL_STEPS,
+      STEPS: FAKE_STEPS,
+      appendAction: (safeTicket, row) => actions.push({ safeTicket, row }),
+    };
+    const ws = transitionStepMod.initialTransitionState(deps, 'GH-768-T');
+    assert.equal(ws.ticketId, 'GH-768-T');
+    assert.equal(ws.currentStep, 1);
+    assert.deepEqual(ws.stepStatus, Object.fromEntries(FAKE_ALL_STEPS.map((s) => [s, 'pending'])));
+    assertAnchor(ws, 'initialTransitionState');
+  });
+
+  it('buildInitialDeferState stamps the anchor on the fresh defer state', () => {
+    assert.equal(
+      typeof nextPreflightMod.buildInitialDeferState,
+      'function',
+      'lib/next-preflight.js must export buildInitialDeferState for direct assertion'
+    );
+    const env = { ALL_STEPS: FAKE_ALL_STEPS };
+    const meta = { safeName: 'GH-768-D', safeBase: 'GH-768-D', suffix: null, separator: null };
+    const timestamp = '2026-07-17T00:00:00.000Z';
+    const ws = nextPreflightMod.buildInitialDeferState(env, meta, ['check'], timestamp);
+    assert.equal(ws.ticketId, 'GH-768-D');
+    assert.deepEqual(ws.deferredSteps, ['check']);
+    assert.equal(ws.lastPlanTimestamp, timestamp);
+    assertAnchor(ws, 'buildInitialDeferState');
+  });
+
+  it('buildMinimalPlanState returns the minimal defer-state shape with the anchor', () => {
+    assert.equal(
+      typeof cliMod.buildMinimalPlanState,
+      'function',
+      'engine/cli.js must export buildMinimalPlanState (extracted from the inline minimalState literal)'
+    );
+    const timestamp = '2026-07-17T00:00:00.000Z';
+    const ws = cliMod.buildMinimalPlanState({
+      ALL_STEPS: FAKE_ALL_STEPS,
+      safeName: 'GH-768-M',
+      timestamp,
+      deferredSteps: ['pr'],
+    });
+    // Field-by-field assertion against the original inline literal shape
+    // (deliverable 2.2.3: extraction changes nothing beyond the anchor fields).
+    assert.equal(ws.ticketId, 'GH-768-M');
+    assert.equal(ws.description, '');
+    assert.equal(ws.currentStep, 1);
+    assert.equal(ws.status, 'in_progress');
+    assert.deepEqual(ws.stepStatus, Object.fromEntries(FAKE_ALL_STEPS.map((s) => [s, 'pending'])));
+    assert.deepEqual(ws.checkProgress, {});
+    assert.deepEqual(ws.errors, []);
+    assert.equal(typeof ws.startTime, 'string');
+    assert.equal(ws.lastPlanTimestamp, timestamp);
+    assert.deepEqual(ws.deferredSteps, ['pr']);
+    assertAnchor(ws, 'buildMinimalPlanState');
+    const expectedKeys = [
+      'ticketId',
+      'description',
+      'currentStep',
+      'status',
+      'stepStatus',
+      'checkProgress',
+      'errors',
+      'startTime',
+      'lastPlanTimestamp',
+      'deferredSteps',
+      'pluginVersionAnchor',
+      'pluginVersionAnchorAt',
+    ];
+    assert.deepEqual(
+      Object.keys(ws).sort(),
+      expectedKeys.slice().sort(),
+      'buildMinimalPlanState must add nothing beyond the original literal shape + anchor fields'
+    );
+  });
+
+  it('initState persists the anchor in the durable .work-state.json', () => {
+    const ticketId = 'GH-768-INIT';
+    const ws = workStateCore.initState(ticketId, 'anchor test');
+    assertAnchor(ws, 'initState (returned state)');
+
+    const statePath = path.join(TEMP_TASKS_BASE, ticketId, '.work-state.json');
+    assert.ok(fs.existsSync(statePath), `state file must exist at ${statePath}`);
+    const onDisk = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+    assertAnchor(onDisk, 'initState (persisted state)');
+  });
+
+  it('initState leaves pre-existing state files without the fields unchanged (no backfill)', () => {
+    const ticketId = 'GH-768-LEGACY';
+    const dir = path.join(TEMP_TASKS_BASE, ticketId);
+    fs.mkdirSync(dir, { recursive: true });
+    const legacy = {
+      ticketId,
+      description: 'pre-feature ticket',
+      currentStep: 3,
+      status: 'in_progress',
+      stepStatus: {},
+      checkProgress: {},
+      errors: [],
+      startTime: '2025-01-01T00:00:00.000Z',
+      lastUpdate: '2025-01-01T00:00:00.000Z',
+    };
+    fs.writeFileSync(path.join(dir, '.work-state.json'), JSON.stringify(legacy, null, 2));
+
+    // initState is idempotent: it must return the existing state untouched.
+    const ws = workStateCore.initState(ticketId);
+    assert.equal(ws.pluginVersionAnchor, undefined, 'no migration/backfill on existing state');
+    assert.equal(ws.pluginVersionAnchorAt, undefined, 'no migration/backfill on existing state');
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, '.work-state.json'), 'utf8'));
+    assert.deepEqual(onDisk, legacy, 'pre-existing state file must load and remain unchanged');
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
@@ -1,0 +1,211 @@
+/**
+ * Tests for version-skew.js — plugin version skew evaluation, anchor stamping,
+ * and the never-throw checkVersionSkew orchestrator (GH-768).
+ *
+ * Contract under test (tasks.md Task 1, R2/R4/R6/R7/R8/R10/R11/R12/R13/R15):
+ * - evaluateVersionSkew(anchor, executing) -> { outcome: 'warn'|'adopt'|'silent' }
+ * - stampVersionAnchor(ws, opts?) — lazy, idempotent, additive optional fields
+ * - checkVersionSkew({ ws, safeName, statePath, appendAction, saveWorkState,
+ *   installedVersion? }) — banner string on warn, null otherwise, never throws.
+ *
+ * node:test + node:assert/strict; every seam dependency-injected — no real FS,
+ * no real workflow run.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+// Defensive load: while lib/version-skew.js does not exist yet (RED phase),
+// fall back to stubs that fail every assertion instead of crashing the runner
+// at collection time.
+let mod;
+try {
+  mod = require('../version-skew');
+} catch {
+  const notImplemented = (name) => () => {
+    throw new Error(`${name} is not implemented (lib/version-skew.js missing)`);
+  };
+  mod = {
+    evaluateVersionSkew: notImplemented('evaluateVersionSkew'),
+    stampVersionAnchor: notImplemented('stampVersionAnchor'),
+    checkVersionSkew: notImplemented('checkVersionSkew'),
+  };
+}
+const { evaluateVersionSkew, stampVersionAnchor, checkVersionSkew } = mod;
+
+const STATE_PATH = '/tmp/tasks/GH-768/.work-state.json';
+
+/** Build a checkVersionSkew deps object with recording fakes. */
+function makeDeps(overrides = {}) {
+  const audits = [];
+  const saves = [];
+  const deps = {
+    ws: { step: 'implement' },
+    safeName: 'GH-768',
+    statePath: STATE_PATH,
+    appendAction: (safeName, row) => {
+      audits.push({ safeName, row });
+    },
+    saveWorkState: (safeName, ws) => {
+      saves.push({ safeName, ws });
+    },
+    installedVersion: '3.78.0',
+    ...overrides,
+  };
+  return { deps, audits, saves };
+}
+
+describe('evaluateVersionSkew', () => {
+  it('returns warn when both versions are valid and different', () => {
+    assert.deepEqual(evaluateVersionSkew('3.70.0', '3.78.0'), { outcome: 'warn' });
+  });
+
+  it('returns silent when versions are equal', () => {
+    assert.deepEqual(evaluateVersionSkew('3.78.0', '3.78.0'), { outcome: 'silent' });
+  });
+
+  it('returns adopt when the anchor is missing but the executing version is valid', () => {
+    assert.deepEqual(evaluateVersionSkew(null, '3.78.0'), { outcome: 'adopt' });
+    assert.deepEqual(evaluateVersionSkew(undefined, '3.78.0'), { outcome: 'adopt' });
+  });
+
+  it('returns adopt when the anchor is garbage but the executing version is valid', () => {
+    assert.deepEqual(evaluateVersionSkew('not-a-version', '3.78.0'), { outcome: 'adopt' });
+  });
+
+  it('returns silent when the executing version is null or invalid', () => {
+    assert.deepEqual(evaluateVersionSkew('3.70.0', null), { outcome: 'silent' });
+    assert.deepEqual(evaluateVersionSkew('3.70.0', 'garbage'), { outcome: 'silent' });
+  });
+
+  it('returns silent when both versions are absent', () => {
+    assert.deepEqual(evaluateVersionSkew(null, null), { outcome: 'silent' });
+  });
+});
+
+describe('stampVersionAnchor', () => {
+  it('stamps pluginVersionAnchor and an ISO pluginVersionAnchorAt on a bare state object', () => {
+    const ws = { step: 'ticket' };
+    stampVersionAnchor(ws, { installedVersion: '3.78.0' });
+    assert.equal(ws.pluginVersionAnchor, '3.78.0');
+    assert.equal(typeof ws.pluginVersionAnchorAt, 'string');
+    assert.ok(
+      !Number.isNaN(Date.parse(ws.pluginVersionAnchorAt)),
+      'pluginVersionAnchorAt must be an ISO timestamp'
+    );
+    // Purely additive: other fields untouched.
+    assert.equal(ws.step, 'ticket');
+  });
+
+  it('is a no-op when an anchor is already present (timestamp untouched)', () => {
+    const ws = {
+      pluginVersionAnchor: '3.70.0',
+      pluginVersionAnchorAt: '2026-01-01T00:00:00.000Z',
+    };
+    stampVersionAnchor(ws, { installedVersion: '3.78.0' });
+    assert.equal(ws.pluginVersionAnchor, '3.70.0');
+    assert.equal(ws.pluginVersionAnchorAt, '2026-01-01T00:00:00.000Z');
+  });
+
+  it('is a no-op when the executing version is unreadable', () => {
+    const ws = { step: 'ticket' };
+    stampVersionAnchor(ws, { installedVersion: null });
+    assert.ok(!('pluginVersionAnchor' in ws));
+    assert.ok(!('pluginVersionAnchorAt' in ws));
+  });
+
+  it('is idempotent across repeated calls', () => {
+    const ws = {};
+    stampVersionAnchor(ws, { installedVersion: '3.78.0' });
+    const at = ws.pluginVersionAnchorAt;
+    stampVersionAnchor(ws, { installedVersion: '3.99.0' });
+    assert.equal(ws.pluginVersionAnchor, '3.78.0');
+    assert.equal(ws.pluginVersionAnchorAt, at);
+  });
+});
+
+describe('checkVersionSkew', () => {
+  it('on skew returns a banner naming both versions and the state path, and appends one audit row', () => {
+    const { deps, audits, saves } = makeDeps({
+      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+    });
+    const banner = checkVersionSkew(deps);
+    assert.equal(typeof banner, 'string');
+    assert.ok(banner.includes('3.78.0'), 'banner names the executing version');
+    assert.ok(banner.includes('3.70.0'), 'banner names the recorded version');
+    assert.ok(banner.includes(STATE_PATH), 'banner names the state-file path');
+
+    assert.equal(audits.length, 1, 'exactly one audit row');
+    assert.equal(audits[0].row.what, 'plugin version skew detected');
+    assert.deepEqual(audits[0].row.meta, {
+      executingVersion: '3.78.0',
+      recordedVersion: '3.70.0',
+      stateFile: STATE_PATH,
+    });
+    // Warn path persists the de-dup marker.
+    assert.equal(deps.ws.versionSkewWarnedFor, '3.78.0');
+    assert.equal(saves.length, 1, 'state saved once to record versionSkewWarnedFor');
+    // Anchor is never re-baselined on warn.
+    assert.equal(deps.ws.pluginVersionAnchor, '3.70.0');
+  });
+
+  it('on match returns null with zero audit rows and zero state writes', () => {
+    const { deps, audits, saves } = makeDeps({
+      ws: { step: 'implement', pluginVersionAnchor: '3.78.0' },
+    });
+    assert.equal(checkVersionSkew(deps), null);
+    assert.equal(audits.length, 0);
+    assert.equal(saves.length, 0);
+  });
+
+  it('on missing anchor adopts: stamps + saves once, returns null, zero skew audit rows', () => {
+    const { deps, audits, saves } = makeDeps({ ws: { step: 'implement' } });
+    assert.equal(checkVersionSkew(deps), null);
+    assert.equal(deps.ws.pluginVersionAnchor, '3.78.0');
+    assert.equal(typeof deps.ws.pluginVersionAnchorAt, 'string');
+    assert.equal(saves.length, 1, 'saveWorkState called exactly once');
+    assert.equal(audits.length, 0, 'no skew audit row on adopt');
+  });
+
+  it('Persistent skew warns on every start but audits once per executing version', () => {
+    const { deps, audits } = makeDeps({
+      ws: {
+        step: 'implement',
+        pluginVersionAnchor: '3.70.0',
+        versionSkewWarnedFor: '3.78.0',
+      },
+    });
+    const banner = checkVersionSkew(deps);
+    assert.equal(typeof banner, 'string', 'banner returned again while skew persists');
+    assert.ok(banner.includes('3.78.0') && banner.includes('3.70.0'));
+    assert.equal(audits.length, 0, 'no second audit row for the same executing version');
+    assert.equal(deps.ws.pluginVersionAnchor, '3.70.0', 'anchor unchanged');
+  });
+
+  it('Unreadable executing version fails open with no warning', () => {
+    const { deps, audits, saves } = makeDeps({
+      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+      installedVersion: null,
+    });
+    let banner;
+    assert.doesNotThrow(() => {
+      banner = checkVersionSkew(deps);
+    });
+    assert.equal(banner, null);
+    assert.equal(audits.length, 0);
+    assert.equal(saves.length, 0);
+  });
+
+  it('Corrupt or throwing audit sink never disrupts the workflow', () => {
+    const { deps } = makeDeps({
+      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+      appendAction: () => {
+        throw new Error('corrupt .work-actions.json');
+      },
+      saveWorkState: () => {
+        throw new Error('disk full');
+      },
+    });
+    assert.doesNotThrow(() => checkVersionSkew(deps));
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
@@ -5,8 +5,16 @@
  * Contract under test (tasks.md Task 1, R2/R4/R6/R7/R8/R10/R11/R12/R13/R15):
  * - evaluateVersionSkew(anchor, executing) -> { outcome: 'warn'|'adopt'|'silent' }
  * - stampVersionAnchor(ws, opts?) — lazy, idempotent, additive optional fields
- * - checkVersionSkew({ ws, safeName, statePath, appendAction, saveWorkState,
- *   installedVersion? }) — banner string on warn, null otherwise, never throws.
+ * - checkVersionSkew({ ws, safeName, statePath, currentStep, appendAction,
+ *   saveWorkState, installedVersion? }) — banner string on warn, null
+ *   otherwise, never throws.
+ *
+ * Fixtures mirror the REAL persisted `.work-state.json` shape (see
+ * work-state/core.js initState / engine/transition-step.js
+ * initialTransitionState): `currentStep` is an integer index and `stepStatus`
+ * is a map — there is NO `step` string field on state. The step NAME for the
+ * audit row is injected by the caller as the `currentStep` dep (resolved via
+ * getCurrentStep()).
  *
  * node:test + node:assert/strict; every seam dependency-injected — no real FS,
  * no real workflow run.
@@ -35,14 +43,29 @@ const { evaluateVersionSkew, stampVersionAnchor, checkVersionSkew } = mod;
 
 const STATE_PATH = '/tmp/tasks/GH-768/.work-state.json';
 
+/**
+ * Minimal REAL persisted work-state shape (initState/initialTransitionState):
+ * integer `currentStep` index + `stepStatus` map, no `step` string field.
+ */
+function makeState(extraFields = {}) {
+  return {
+    ticketId: 'GH-768',
+    currentStep: 4,
+    status: 'in_progress',
+    stepStatus: { ticket: 'completed', spec: 'completed', implement: 'in_progress' },
+    ...extraFields,
+  };
+}
+
 /** Build a checkVersionSkew deps object with recording fakes. */
 function makeDeps(overrides = {}) {
   const audits = [];
   const saves = [];
   const deps = {
-    ws: { step: 'implement' },
+    ws: makeState(),
     safeName: 'GH-768',
     statePath: STATE_PATH,
+    currentStep: 'implement',
     appendAction: (safeName, row) => {
       audits.push({ safeName, row });
     },
@@ -85,7 +108,7 @@ describe('evaluateVersionSkew', () => {
 
 describe('stampVersionAnchor', () => {
   it('stamps pluginVersionAnchor and an ISO pluginVersionAnchorAt on a bare state object', () => {
-    const ws = { step: 'ticket' };
+    const ws = makeState({ currentStep: 1 });
     stampVersionAnchor(ws, { installedVersion: '3.78.0' });
     assert.equal(ws.pluginVersionAnchor, '3.78.0');
     assert.equal(typeof ws.pluginVersionAnchorAt, 'string');
@@ -94,7 +117,8 @@ describe('stampVersionAnchor', () => {
       'pluginVersionAnchorAt must be an ISO timestamp'
     );
     // Purely additive: other fields untouched.
-    assert.equal(ws.step, 'ticket');
+    assert.equal(ws.currentStep, 1);
+    assert.equal(ws.stepStatus.implement, 'in_progress');
   });
 
   it('is a no-op when an anchor is already present (timestamp untouched)', () => {
@@ -108,7 +132,7 @@ describe('stampVersionAnchor', () => {
   });
 
   it('is a no-op when the executing version is unreadable', () => {
-    const ws = { step: 'ticket' };
+    const ws = makeState({ currentStep: 1 });
     stampVersionAnchor(ws, { installedVersion: null });
     assert.ok(!('pluginVersionAnchor' in ws));
     assert.ok(!('pluginVersionAnchorAt' in ws));
@@ -127,7 +151,7 @@ describe('stampVersionAnchor', () => {
 describe('checkVersionSkew', () => {
   it('on skew returns a banner naming both versions and the state path, and appends one audit row', () => {
     const { deps, audits, saves } = makeDeps({
-      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+      ws: makeState({ pluginVersionAnchor: '3.70.0' }),
     });
     const banner = checkVersionSkew(deps);
     assert.equal(typeof banner, 'string');
@@ -137,6 +161,9 @@ describe('checkVersionSkew', () => {
 
     assert.equal(audits.length, 1, 'exactly one audit row');
     assert.equal(audits[0].row.what, 'plugin version skew detected');
+    // Step name comes from the injected currentStep dep — the state itself
+    // has no `step` string field (would serialize as an absent key).
+    assert.equal(audits[0].row.step, 'implement', 'audit row carries the resolved step name');
     assert.deepEqual(audits[0].row.meta, {
       executingVersion: '3.78.0',
       recordedVersion: '3.70.0',
@@ -151,7 +178,7 @@ describe('checkVersionSkew', () => {
 
   it('on match returns null with zero audit rows and zero state writes', () => {
     const { deps, audits, saves } = makeDeps({
-      ws: { step: 'implement', pluginVersionAnchor: '3.78.0' },
+      ws: makeState({ pluginVersionAnchor: '3.78.0' }),
     });
     assert.equal(checkVersionSkew(deps), null);
     assert.equal(audits.length, 0);
@@ -159,7 +186,7 @@ describe('checkVersionSkew', () => {
   });
 
   it('on missing anchor adopts: stamps + saves once, returns null, zero skew audit rows', () => {
-    const { deps, audits, saves } = makeDeps({ ws: { step: 'implement' } });
+    const { deps, audits, saves } = makeDeps({ ws: makeState() });
     assert.equal(checkVersionSkew(deps), null);
     assert.equal(deps.ws.pluginVersionAnchor, '3.78.0');
     assert.equal(typeof deps.ws.pluginVersionAnchorAt, 'string');
@@ -169,11 +196,10 @@ describe('checkVersionSkew', () => {
 
   it('Persistent skew warns on every start but audits once per executing version', () => {
     const { deps, audits } = makeDeps({
-      ws: {
-        step: 'implement',
+      ws: makeState({
         pluginVersionAnchor: '3.70.0',
         versionSkewWarnedFor: '3.78.0',
-      },
+      }),
     });
     const banner = checkVersionSkew(deps);
     assert.equal(typeof banner, 'string', 'banner returned again while skew persists');
@@ -184,7 +210,7 @@ describe('checkVersionSkew', () => {
 
   it('Unreadable executing version fails open with no warning', () => {
     const { deps, audits, saves } = makeDeps({
-      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+      ws: makeState({ pluginVersionAnchor: '3.70.0' }),
       installedVersion: null,
     });
     let banner;
@@ -198,7 +224,7 @@ describe('checkVersionSkew', () => {
 
   it('Corrupt or throwing audit sink never disrupts the workflow', () => {
     const { deps } = makeDeps({
-      ws: { step: 'implement', pluginVersionAnchor: '3.70.0' },
+      ws: makeState({ pluginVersionAnchor: '3.70.0' }),
       appendAction: () => {
         throw new Error('corrupt .work-actions.json');
       },

--- a/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
+++ b/plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
@@ -131,6 +131,16 @@ describe('stampVersionAnchor', () => {
     assert.equal(ws.pluginVersionAnchorAt, '2026-01-01T00:00:00.000Z');
   });
 
+  it('repairs a corrupt (non-semver) anchor instead of preserving it', () => {
+    const ws = makeState({
+      pluginVersionAnchor: 'garbage-not-a-version',
+      pluginVersionAnchorAt: '2026-01-01T00:00:00.000Z',
+    });
+    stampVersionAnchor(ws, { installedVersion: '3.78.0' });
+    assert.equal(ws.pluginVersionAnchor, '3.78.0');
+    assert.notEqual(ws.pluginVersionAnchorAt, '2026-01-01T00:00:00.000Z');
+  });
+
   it('is a no-op when the executing version is unreadable', () => {
     const ws = makeState({ currentStep: 1 });
     stampVersionAnchor(ws, { installedVersion: null });
@@ -192,6 +202,16 @@ describe('checkVersionSkew', () => {
     assert.equal(typeof deps.ws.pluginVersionAnchorAt, 'string');
     assert.equal(saves.length, 1, 'saveWorkState called exactly once');
     assert.equal(audits.length, 0, 'no skew audit row on adopt');
+  });
+
+  it('on corrupt anchor adopts: repairs the anchor, saves once, returns null, zero skew audit rows', () => {
+    const { deps, audits, saves } = makeDeps({
+      ws: makeState({ pluginVersionAnchor: 'garbage-not-a-version' }),
+    });
+    assert.equal(checkVersionSkew(deps), null);
+    assert.equal(deps.ws.pluginVersionAnchor, '3.78.0', 'corrupt anchor repaired');
+    assert.equal(audits.length, 0);
+    assert.equal(saves.length, 1);
   });
 
   it('Persistent skew warns on every start but audits once per executing version', () => {

--- a/plugins/work/scripts/workflows/work/lib/next-instruction.js
+++ b/plugins/work/scripts/workflows/work/lib/next-instruction.js
@@ -265,6 +265,23 @@ function generatePlanSafe(env, resolved, ticketRaw, rework) {
   }
 }
 
+/**
+ * GH-768: plugin version skew check — once per top-level invocation
+ * (auto-advance recursion re-enters with recursionDepth > 1). Warn-only:
+ * a non-null banner is surfaced via stateCtx.versionSkew, never a block.
+ */
+function maybeAttachVersionSkew(env, { recursionDepth, preCheckState, safeName, stateCtx }) {
+  if (recursionDepth !== 1) return;
+  const versionSkew = checkVersionSkew({
+    ws: preCheckState,
+    safeName,
+    statePath: path.join(env.TASKS_BASE, safeName, '.work-state.json'),
+    appendAction: env.appendAction,
+    saveWorkState: env.saveWorkState,
+  });
+  if (versionSkew) stateCtx.versionSkew = versionSkew;
+}
+
 function createGetNextInstruction(env) {
   let recursionDepth = 0;
 
@@ -302,26 +319,12 @@ function createGetNextInstruction(env) {
     if (shortCircuit) return shortCircuit;
     preflight.debugTrace(env, preCheckState, safeName, recursionDepth);
 
-    // GH-768: plugin version skew check — once per top-level invocation
-    // (auto-advance recursion re-enters with recursionDepth > 1). Warn-only:
-    // a non-null banner is surfaced via stateCtx.versionSkew, never a block.
-    const versionSkew =
-      recursionDepth === 1
-        ? checkVersionSkew({
-            ws: preCheckState,
-            safeName,
-            statePath: path.join(env.TASKS_BASE, safeName, '.work-state.json'),
-            appendAction: env.appendAction,
-            saveWorkState: env.saveWorkState,
-          })
-        : null;
-
     const stateCtx = buildStateContext(ticket, plan, safeName, {
       loadWorkState: env.loadWorkState,
       getCurrentStep: env.getCurrentStep,
       ALL_STEPS: env.ALL_STEPS,
     });
-    if (versionSkew) stateCtx.versionSkew = versionSkew;
+    maybeAttachVersionSkew(env, { recursionDepth, preCheckState, safeName, stateCtx });
     const recurse = () => getNextInstruction(ticketRaw, rework);
     if (result.nextAction === 'advance_task' && handleAdvanceTask(env, safeName)) {
       return recurse();

--- a/plugins/work/scripts/workflows/work/lib/next-instruction.js
+++ b/plugins/work/scripts/workflows/work/lib/next-instruction.js
@@ -276,6 +276,9 @@ function maybeAttachVersionSkew(env, { recursionDepth, preCheckState, safeName, 
     ws: preCheckState,
     safeName,
     statePath: path.join(env.TASKS_BASE, safeName, '.work-state.json'),
+    // The persisted state has no `step` string field — resolve the current
+    // step name from stepStatus via the shared accessor for the audit row.
+    currentStep: env.getCurrentStep(preCheckState),
     appendAction: env.appendAction,
     saveWorkState: env.saveWorkState,
   });

--- a/plugins/work/scripts/workflows/work/lib/next-instruction.js
+++ b/plugins/work/scripts/workflows/work/lib/next-instruction.js
@@ -20,6 +20,7 @@ const { buildInstruction } = require('./instruction-builder');
 const { buildStateContext } = require('./state-context');
 const { enrich, runGate } = require('./step-enrichments');
 const { createDebugLog } = require('./debug-log');
+const { checkVersionSkew } = require('./version-skew');
 const preflight = require('./next-preflight');
 
 const MAX_RECURSION = 10;
@@ -301,11 +302,26 @@ function createGetNextInstruction(env) {
     if (shortCircuit) return shortCircuit;
     preflight.debugTrace(env, preCheckState, safeName, recursionDepth);
 
+    // GH-768: plugin version skew check — once per top-level invocation
+    // (auto-advance recursion re-enters with recursionDepth > 1). Warn-only:
+    // a non-null banner is surfaced via stateCtx.versionSkew, never a block.
+    const versionSkew =
+      recursionDepth === 1
+        ? checkVersionSkew({
+            ws: preCheckState,
+            safeName,
+            statePath: path.join(env.TASKS_BASE, safeName, '.work-state.json'),
+            appendAction: env.appendAction,
+            saveWorkState: env.saveWorkState,
+          })
+        : null;
+
     const stateCtx = buildStateContext(ticket, plan, safeName, {
       loadWorkState: env.loadWorkState,
       getCurrentStep: env.getCurrentStep,
       ALL_STEPS: env.ALL_STEPS,
     });
+    if (versionSkew) stateCtx.versionSkew = versionSkew;
     const recurse = () => getNextInstruction(ticketRaw, rework);
     if (result.nextAction === 'advance_task' && handleAdvanceTask(env, safeName)) {
       return recurse();

--- a/plugins/work/scripts/workflows/work/lib/next-preflight.js
+++ b/plugins/work/scripts/workflows/work/lib/next-preflight.js
@@ -17,6 +17,7 @@ const fs = require('fs');
 const { execFileSync } = require('child_process');
 
 const { normalizeTicketBase } = require('./session-conflict');
+const { stampVersionAnchor } = require('./version-skew');
 
 function emptyProgressState(ticket) {
   return {
@@ -103,7 +104,7 @@ function backfillTicketIdentity(planState, meta) {
 }
 
 function buildInitialDeferState(env, meta, deferredSteps, timestamp) {
-  return {
+  const ws = {
     ticketId: meta.safeName,
     ticketBase: meta.safeBase,
     ticketSuffix: meta.suffix || null,
@@ -118,6 +119,8 @@ function buildInitialDeferState(env, meta, deferredSteps, timestamp) {
     lastPlanTimestamp: timestamp,
     deferredSteps,
   };
+  stampVersionAnchor(ws);
+  return ws;
 }
 
 /**
@@ -288,6 +291,7 @@ function debugTrace(env, preCheckState, safeName, recursionDepth) {
 
 module.exports = {
   blockedInstruction,
+  buildInitialDeferState,
   resolveTicket,
   syncSessionGuardFile,
   persistPlanMetadata,

--- a/plugins/work/scripts/workflows/work/lib/version-skew.js
+++ b/plugins/work/scripts/workflows/work/lib/version-skew.js
@@ -107,11 +107,14 @@ function buildSkewBanner(executingVersion, recordedVersion, statePath) {
  * @param {string} executingVersion
  */
 function recordSkewOnce(deps, executingVersion) {
-  const { ws, safeName, statePath, appendAction, saveWorkState } = deps;
+  const { ws, safeName, statePath, currentStep, appendAction, saveWorkState } = deps;
   if (ws.versionSkewWarnedFor === executingVersion) return;
   try {
     appendAction(safeName, {
-      step: ws.step,
+      // The persisted work-state has no `step` string field (only the
+      // `currentStep` index + `stepStatus` map), so the caller resolves the
+      // step name via getCurrentStep() and injects it as `currentStep`.
+      step: currentStep,
       what: 'plugin version skew detected',
       meta: {
         executingVersion,
@@ -143,6 +146,7 @@ function recordSkewOnce(deps, executingVersion) {
  *   ws: object,
  *   safeName: string,
  *   statePath: string,
+ *   currentStep?: string,
  *   appendAction: (safeName: string, row: object) => void,
  *   saveWorkState: (safeName: string, ws: object) => void,
  *   installedVersion?: string|null,

--- a/plugins/work/scripts/workflows/work/lib/version-skew.js
+++ b/plugins/work/scripts/workflows/work/lib/version-skew.js
@@ -1,0 +1,181 @@
+'use strict';
+
+/**
+ * version-skew.js — plugin version skew detection for /work tickets (GH-768).
+ *
+ * Every fresh `.work-state.json` records the plugin version that created it
+ * (`pluginVersionAnchor` + `pluginVersionAnchorAt`). At workflow start the
+ * anchor is compared against the executing plugin version and one of three
+ * outcomes applies:
+ *
+ *   - `warn`   — both versions are valid and different: return a loud WARN
+ *                banner (never a block) and append ONE audit row per distinct
+ *                executing version (de-duplicated via `ws.versionSkewWarnedFor`).
+ *   - `adopt`  — the anchor is missing/invalid but the executing version is
+ *                valid: stamp the anchor silently (graceful degradation for
+ *                pre-feature tickets) and persist it.
+ *   - `silent` — versions match, or the executing version is unreadable:
+ *                do nothing (no banner, no audit row, no state write).
+ *
+ * NEVER-THROW CONVENTION (mirrors `maybeUpdateBanner` in update-check.js):
+ * any failure reading either version, or any injected dependency throwing,
+ * falls back to "no warning" — this module must never disrupt the host
+ * command.
+ *
+ * The anchor fields are lazily-created OPTIONAL fields on the durable
+ * per-ticket `.work-state.json` (the `gateFingerprints` back-compat pattern):
+ * pre-existing state files load unchanged; there is no migration or backfill.
+ *
+ * Reuse: `readInstalledVersion()` / `isValidVersion()` from update-check.js
+ * are the ONLY version-read/validation seams — no new heuristics.
+ */
+
+const { isValidVersion, readInstalledVersion } = require('./update-check');
+
+/**
+ * Pure decision function for the three-outcome skew contract.
+ *
+ * @param {string|null|undefined} anchorVersion version recorded in state
+ * @param {string|null|undefined} executingVersion currently installed version
+ * @returns {{ outcome: 'warn' | 'adopt' | 'silent' }}
+ */
+function evaluateVersionSkew(anchorVersion, executingVersion) {
+  if (!isValidVersion(executingVersion)) return { outcome: 'silent' };
+  if (!isValidVersion(anchorVersion)) return { outcome: 'adopt' };
+  return anchorVersion === executingVersion ? { outcome: 'silent' } : { outcome: 'warn' };
+}
+
+/**
+ * Resolve the executing plugin version from an options/deps object. When the
+ * caller injected `installedVersion` (tests, checkVersionSkew fan-out), honor
+ * it verbatim — even null — otherwise fall back to the real plugin.json read.
+ *
+ * @param {object} source options/deps object that may carry `installedVersion`
+ * @returns {string|null}
+ */
+function resolveInstalledVersion(source) {
+  if (source && 'installedVersion' in source) return source.installedVersion;
+  return readInstalledVersion();
+}
+
+/**
+ * Lazily stamp the version anchor on a work-state object. Idempotent and
+ * purely additive: a no-op when an anchor is already present (the original
+ * anchor and its timestamp are never overwritten) or when the executing
+ * version is unreadable/invalid. Never throws.
+ *
+ * @param {object} ws mutable work-state object
+ * @param {{ installedVersion?: string|null }} [opts] injectable version source
+ * @returns {void}
+ */
+function stampVersionAnchor(ws, opts = {}) {
+  try {
+    if (!ws || typeof ws !== 'object') return;
+    if (ws.pluginVersionAnchor != null) return;
+    const version = resolveInstalledVersion(opts);
+    if (!isValidVersion(version)) return;
+    ws.pluginVersionAnchor = version;
+    ws.pluginVersionAnchorAt = new Date().toISOString();
+  } catch {
+    /* never-throw: fall back to no stamp */
+  }
+}
+
+/**
+ * Build the loud WARN banner naming the executing version, the recorded
+ * version, and the state file that recorded the anchor.
+ *
+ * @param {string} executingVersion
+ * @param {string} recordedVersion
+ * @param {string} statePath
+ * @returns {string}
+ */
+function buildSkewBanner(executingVersion, recordedVersion, statePath) {
+  return [
+    `WARN: plugin version skew — this workflow is executing plugin version ${executingVersion},`,
+    `but ${statePath} recorded version ${recordedVersion} when the ticket was created.`,
+    'The workflow continues (warn-only, never a block); behavior may differ from the recorded run.',
+  ].join('\n');
+}
+
+/**
+ * Append the skew audit row and persist the per-executing-version de-dup
+ * marker. Each side-effect is individually guarded so a corrupt/throwing
+ * sink never disrupts the workflow.
+ *
+ * @param {object} deps see checkVersionSkew
+ * @param {string} executingVersion
+ */
+function recordSkewOnce(deps, executingVersion) {
+  const { ws, safeName, statePath, appendAction, saveWorkState } = deps;
+  if (ws.versionSkewWarnedFor === executingVersion) return;
+  try {
+    appendAction(safeName, {
+      step: ws.step,
+      what: 'plugin version skew detected',
+      meta: {
+        executingVersion,
+        recordedVersion: ws.pluginVersionAnchor,
+        stateFile: statePath,
+      },
+    });
+  } catch {
+    /* audit sink failure is non-fatal */
+  }
+  ws.versionSkewWarnedFor = executingVersion;
+  try {
+    saveWorkState(safeName, ws);
+  } catch {
+    /* state-save failure is non-fatal */
+  }
+}
+
+/**
+ * Workflow-start orchestrator: evaluate skew and apply the outcome.
+ *
+ * Returns data only — a WARN banner string on skew, `null` otherwise. No
+ * `process.exit`, no blocked instruction, no transition gate. The banner
+ * repeats on every start while skew persists (the anchor is never
+ * re-baselined on warn); the audit row is appended once per distinct
+ * executing version.
+ *
+ * @param {{
+ *   ws: object,
+ *   safeName: string,
+ *   statePath: string,
+ *   appendAction: (safeName: string, row: object) => void,
+ *   saveWorkState: (safeName: string, ws: object) => void,
+ *   installedVersion?: string|null,
+ * }} deps injected seams (no real FS in tests)
+ * @returns {string|null} WARN banner on skew, null otherwise
+ */
+function checkVersionSkew(deps) {
+  try {
+    const { ws, safeName, statePath, saveWorkState } = deps || {};
+    if (!ws || typeof ws !== 'object') return null;
+    const executingVersion = resolveInstalledVersion(deps);
+    const { outcome } = evaluateVersionSkew(ws.pluginVersionAnchor, executingVersion);
+    if (outcome === 'silent') return null;
+    if (outcome === 'adopt') {
+      stampVersionAnchor(ws, { installedVersion: executingVersion });
+      try {
+        saveWorkState(safeName, ws);
+      } catch {
+        /* state-save failure is non-fatal */
+      }
+      return null;
+    }
+    const banner = buildSkewBanner(executingVersion, ws.pluginVersionAnchor, statePath);
+    recordSkewOnce(deps, executingVersion);
+    return banner;
+  } catch {
+    /* never-throw: fall back to no warning */
+    return null;
+  }
+}
+
+module.exports = {
+  evaluateVersionSkew,
+  stampVersionAnchor,
+  checkVersionSkew,
+};

--- a/plugins/work/scripts/workflows/work/lib/version-skew.js
+++ b/plugins/work/scripts/workflows/work/lib/version-skew.js
@@ -60,9 +60,12 @@ function resolveInstalledVersion(source) {
 
 /**
  * Lazily stamp the version anchor on a work-state object. Idempotent and
- * purely additive: a no-op when an anchor is already present (the original
+ * purely additive: a no-op when a VALID anchor is already present (a valid
  * anchor and its timestamp are never overwritten) or when the executing
- * version is unreadable/invalid. Never throws.
+ * version is unreadable/invalid. A corrupt (non-semver) anchor is repaired —
+ * otherwise the `adopt` outcome would re-save an unchanged state on every
+ * workflow start and the garbage anchor would persist for the ticket's
+ * lifetime. Never throws.
  *
  * @param {object} ws mutable work-state object
  * @param {{ installedVersion?: string|null }} [opts] injectable version source
@@ -71,7 +74,7 @@ function resolveInstalledVersion(source) {
 function stampVersionAnchor(ws, opts = {}) {
   try {
     if (!ws || typeof ws !== 'object') return;
-    if (ws.pluginVersionAnchor != null) return;
+    if (isValidVersion(ws.pluginVersionAnchor)) return;
     const version = resolveInstalledVersion(opts);
     if (!isValidVersion(version)) return;
     ws.pluginVersionAnchor = version;

--- a/plugins/work/scripts/workflows/work/work-state/core.js
+++ b/plugins/work/scripts/workflows/work/work-state/core.js
@@ -32,6 +32,7 @@ const TASKS_BASE = config.TASKS_BASE;
 
 const { ALL_STEPS: STEPS } = require(path.join(__dirname, '..', 'step-registry'));
 const { taskSegment } = require('../../lib/allocate-output-folder');
+const { stampVersionAnchor } = require('../lib/version-skew');
 
 const SUBTASK_STEPS = ['implement', 'commit'];
 
@@ -107,6 +108,7 @@ function initState(ticketId, description = '') {
     startTime: new Date().toISOString(),
     lastUpdate: new Date().toISOString(),
   };
+  stampVersionAnchor(state);
 
   return saveState(ticketId, state);
 }


### PR DESCRIPTION
## Summary

- Adds plugin version skew detection at workflow start (GH-768, epic GH-750 Phase 5.2): every new ticket state records a `pluginVersionAnchor`; on resume, a version mismatch surfaces a WARN banner and one audit row per distinct executing version, while matching versions stay silent.
- Introduces `plugins/work/lib/version-skew.js` (three exports: `evaluateVersionSkew`, `stampVersionAnchor`, `checkVersionSkew`) and wires it into `createGetNextInstruction` via `maybeAttachVersionSkew` (once per top-level invocation, never on auto-advance recursion).
- Decomposes the `cli.js` monolithic `main` into named helper functions and removes the file from `.quality-exceptions`.

## Existing Behavior

- New tickets and resumed tickets carry no plugin version record; the harness version executing mid-run is invisible in the ticket state.
- When the plugin is bumped mid-fleet, in-flight tickets silently execute cached harness code against state generated by a different version; the operator discovers the mismatch only after a wedge.
- `work/engine/cli.js` monolithic `main` function was in the `.quality-exceptions` allowlist.

## Intended New Behavior

- Every fresh work-state records a `pluginVersionAnchor` (version string + ISO timestamp) at the moment the ticket state is first created; four fresh-state constructor paths all stamp the anchor.
- At every workflow start, `maybeAttachVersionSkew` compares the executing plugin version against the recorded anchor once per top-level invocation; a version mismatch surfaces a loud WARN banner in the step instruction and appends one audit row to `.work-actions.json` (de-duplicated per executing version), while matching versions stay silent.
- Tickets created before this feature (no recorded version) silently adopt the anchor on first resume — no false warning, no hard block.
- `cli.js` is decomposed into named helper functions and removed from `.quality-exceptions`.

## Brief P0 coverage

- **P0 #1:** Version anchor on ticket creation — `plugins/work/scripts/workflows/work/engine/cli.js` (four `stampVersionAnchor` call sites: `buildMinimalPlanState`, `buildLoadedState`, fresh-bootstrap path, `work-state/core.js`)
- **P0 #2:** Skew check at workflow start — `plugins/work/scripts/workflows/work/lib/next-instruction.js:maybeAttachVersionSkew` + `lib/version-skew.js:checkVersionSkew`
- **P0 #3:** Loud warning on skew, never a block — `lib/version-skew.js:buildSkewBanner` + `recordSkewOnce`; covered by `lib/__tests__/version-skew.test.js`
- **P0 #4:** Silent on match — `lib/version-skew.js:evaluateVersionSkew` returns `silent` when versions equal; covered by `lib/__tests__/version-skew.test.js`
- **P0 #5:** Graceful degradation for pre-feature tickets — `lib/version-skew.js:checkVersionSkew` adopt path; covered by `lib/__tests__/version-skew.test.js`
- **P0 #6:** Unit tests for P0 items 3-5 — 25 tests across `version-skew.test.js`, `next-instruction-version-skew.e2e.test.js`, `version-anchor-creation.e2e.test.js`

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Test plan

### Verify skew detection end-to-end

1. Start a ticket with the current plugin version; confirm the persisted ticket state contains `pluginVersionAnchor` matching the running version and a `pluginVersionAnchorAt` ISO timestamp.

2. Patch the anchor field in the persisted ticket state to an older version (e.g. `3.70.0`) and resume. Expected: step instruction contains the WARN banner naming both versions and the state-file path; `.work-actions.json` gains a `plugin version skew detected` audit row.

3. Resume again without modifying state. Expected: banner repeats; `.work-actions.json` gains no second audit row for the same executing version.

4. Restore the anchor to the current version and resume. Expected: no banner, no audit row.

5. Run the unit and e2e test suites:
   ```bash
   node --test plugins/work/scripts/workflows/work/lib/__tests__/version-skew.test.js
   node --test plugins/work/scripts/workflows/work/__tests__/next-instruction-version-skew.e2e.test.js
   node --test plugins/work/scripts/workflows/work/__tests__/version-anchor-creation.e2e.test.js
   ```
   Expected: all 25 tests pass.

### Test Results

Full suite (8619 tests) green; quality gate exits clean.

## Linked tickets

- GH-750 (parent epic, Phase 5.2)
- GH-767, GH-769, GH-763, GH-764, GH-765, GH-766 (parallel siblings)

Closes #768