### PR TITLE
feat(work): single agent-identity module for all hooks (GH-767)

### DIFF
--- a/.quality-exceptions
+++ b/.quality-exceptions
@@ -74,7 +74,6 @@ plugins/work/scripts/workflows/work/lib/gherkin-task-refs.js
 plugins/work/scripts/workflows/check/agents/qa-feature-tester/qa-screenshot-validator.js
 plugins/work/scripts/workflows/work/engine/cli.js
 plugins/work/scripts/workflows/work/lib/work-actions.js
-plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
 plugins/work/scripts/workflows/work/steps/implement.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/draft.js
 plugins/work/scripts/workflows/check/scripts/write-qa-report.js
@@ -95,7 +94,6 @@ plugins/work/scripts/workflows/work/engine/plan-generator.js
 plugins/work/scripts/workflows/check/agents/qa-api-tester/validate-api-report.js
 plugins/work/scripts/workflows/work/scripts/bootstrap-custom-script.js
 plugins/work/scripts/workflows/work/lib/mark-task-progress.js
-plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
 plugins/work/scripts/workflows/work-spec/lib/kind-checks/e2e.js
 plugins/work/scripts/workflows/lib/allocate-output-folder.js
 plugins/work/scripts/workflows/check/scripts/write-tests-report.js
@@ -156,7 +154,6 @@ plugins/work/scripts/workflows/work/agents/developer-quality-gate.js
 plugins/work/scripts/workflows/work-code-checker/lib/kind-checks/devops.js
 plugins/work/scripts/workflows/work-task-review/lib/kind-checks/shared.js
 plugins/work/scripts/workflows/work-task-review/lib/phases/report.js
-plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
 plugins/work/scripts/workflows/lib/scripts/get-ticket-id.js
 plugins/work/scripts/workflows/work-tasks/lib/phases/memorize.js
 plugins/work/scripts/workflows/work-pr-step/lib/phases/attachments.js

--- a/plugins/work/CLAUDE.md
+++ b/plugins/work/CLAUDE.md
@@ -106,6 +106,25 @@ Load-bearing facts when porting:
   `.work-actions.json` (`tdd-exception`). Agents get TDD exemptions ONLY via
   the planner's `### Type` line, never by invoking `exception`.
 
+### Agent Identity (hook authors)
+
+All agent-identity questions in hooks go through the canonical module
+`scripts/workflows/lib/agent-identity.js` — never probe the payload, env, or
+transcript directly. Its contract JSDoc documents six distinct questions:
+"am I agent X?" (`isRunningInAgent`), "am I ANY dispatched agent?"
+(`isDispatchedAgentContext`, env-sensitive by design), "am I a subagent?"
+(`isSubagentContext`, env-blind by design — do not merge with the previous),
+"what does the payload say I am?" (`payloadAgentName`), "which agent is being
+dispatched?" (`dispatchTargetAgent` — a dispatch target is never
+self-identity), and "what does env claim?" (`envAgentName` — spoofable,
+lowest trust). Signal precedence is payload → transcript structural markers →
+env. New hooks import these accessors instead of reading
+`process.env.CLAUDE_CURRENT_AGENT`, `agent_type`/`agent_name`/`subagent_type`,
+or transcript markers inline — a grep-guard test enforces this. The module's
+JSDoc header sections — "The six identity questions", "The #665 rule",
+"Fail directions", and "Observability" — are the authoritative contract this
+paragraph points at.
+
 ### Security
 - All ticket-ID-to-path conversions validated against directory traversal.
 - `protect-state-files.js` guards `.work-state.json` etc. from direct edits.

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-identity-665-regression.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-identity-665-regression.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+/**
+ * PERMANENT FIXTURE — GH-665 regression suite. DO NOT DELETE.
+ *
+ * Pins the fix for the GH-665 bricked-session incident class: a PLAIN MAIN
+ * SESSION whose opening prompt merely SAYS "use the commit-writer agent to
+ * commit staged changes" (and whose text carries git tokens) was classified
+ * as the commit-writer agent by name-substring matching against user prose.
+ * Agent-gated guards then fired inside the user's main session — blocking
+ * ordinary git/gh commands and bricking the session.
+ *
+ * The rule this suite pins (see lib/agent-identity.js, "The #665 rule"):
+ * name-substring matching against prose is only permitted inside a transcript
+ * POSITIVELY identified as a sidechain (`isSidechain` / `attributionAgent`
+ * structural markers). Never in main-session text, never in command text.
+ *
+ * Two fixtures prove the gate is live, not dead:
+ *   1. Regression: a markerless main-session transcript with the literal
+ *      #665 prompt shape must classify as NOT commit-writer.
+ *   2. Control: the SAME prompt in a transcript carrying an early
+ *      `isSidechain: true` marker MUST classify as commit-writer — proving
+ *      the negative assertion gates on structural markers rather than on a
+ *      check that never matches anything.
+ *
+ * This suite is a permanent regression fixture. Do not delete it, weaken its
+ * assertions, or fold it into another suite: it is the executable record of
+ * the GH-665 incident class, and its removal would allow prose-based agent
+ * classification to regress silently.
+ *
+ * Run: node --test plugins/work/scripts/workflows/lib/__tests__/agent-identity-665-regression.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { isRunningInAgent, isSubagentFromInitialPrompt } = require('../agent-identity');
+
+// Transcripts live in a private mkdtemp tmpdir (unpredictable name) so a
+// predictable filename cannot be exploited via a symlink/race attack.
+const TRANSCRIPT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-identity-665-'));
+process.on('exit', () => {
+  try {
+    fs.rmSync(TRANSCRIPT_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// Build a claude JSONL transcript file from line objects; returns its path.
+function writeTranscript(lines) {
+  const tmp = path.join(
+    TRANSCRIPT_DIR,
+    `t-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+  );
+  fs.writeFileSync(tmp, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+  return tmp;
+}
+
+// The literal #665 prompt shape: an agent-name mention in user prose PLUS a
+// command line carrying git tokens — exactly the text that misclassified a
+// plain main session as commit-writer before the fix.
+const GH665_PROMPT =
+  'use the commit-writer agent to commit staged changes for GH-665\n' +
+  'then run: git add -A && git commit -m "fix: guard the thing" && git push origin main';
+
+// ─── Env hygiene: identity env vars must not decide these tests ─────────────
+
+const SAVED_ENV_KEYS = ['CLAUDE_CURRENT_AGENT', 'CLAUDE_AGENT_TYPE', 'ENFORCE_HOOK_DEBUG'];
+const savedEnv = {};
+
+beforeEach(() => {
+  for (const key of SAVED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of SAVED_ENV_KEYS) {
+    if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+    else delete process.env[key];
+  }
+});
+
+describe('GH-665 regression — markerless main session mentioning an agent name', () => {
+  // No isSidechain, no attributionAgent: a plain main-session transcript.
+  function markerlessFixture() {
+    return writeTranscript([
+      {
+        type: 'user',
+        message: { role: 'user', content: GH665_PROMPT },
+      },
+    ]);
+  }
+
+  it('isRunningInAgent must NOT classify the main session as commit-writer', () => {
+    const transcriptPath = markerlessFixture();
+    assert.equal(
+      isRunningInAgent(transcriptPath, ['commit-writer'], {}),
+      false,
+      'GH-665 regression: a main session that merely SAYS "use the commit-writer ' +
+        'agent" must never classify as commit-writer'
+    );
+  });
+
+  it('isSubagentFromInitialPrompt must NOT match a markerless name mention', () => {
+    const transcriptPath = markerlessFixture();
+    assert.equal(
+      isSubagentFromInitialPrompt(transcriptPath, ['commit-writer']),
+      false,
+      'GH-665 regression: prose name-mention matching is forbidden without a ' +
+        'structural sidechain marker'
+    );
+  });
+});
+
+describe('GH-665 control — sidechain transcript with the same name mention', () => {
+  // Identical prompt, but the transcript is POSITIVELY a sidechain: the early
+  // `isSidechain: true` structural marker permits the name-mention fallback.
+  // This control proves the negative assertions above gate on structural
+  // markers rather than on a dead check that matches nothing.
+  function sidechainFixture() {
+    return writeTranscript([
+      {
+        type: 'user',
+        isSidechain: true,
+        message: { role: 'user', content: GH665_PROMPT },
+      },
+    ]);
+  }
+
+  it('isRunningInAgent classifies the sidechain transcript as commit-writer', () => {
+    const transcriptPath = sidechainFixture();
+    assert.equal(
+      isRunningInAgent(transcriptPath, ['commit-writer'], {}),
+      true,
+      'control: the SAME prompt inside a genuine sidechain must still classify ' +
+        'as commit-writer — otherwise the regression assertions test a dead gate'
+    );
+  });
+
+  it('isSubagentFromInitialPrompt matches the sidechain name mention', () => {
+    const transcriptPath = sidechainFixture();
+    assert.equal(
+      isSubagentFromInitialPrompt(transcriptPath, ['commit-writer']),
+      true,
+      'control: sidechain-gated name-mention matching must remain live'
+    );
+  });
+});

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-identity-grep-guard.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-identity-grep-guard.test.js
@@ -1,0 +1,370 @@
+'use strict';
+
+/**
+ * Grep-guard for the agent-identity module boundary (GH-767, Task 6).
+ *
+ * Self-scanning suite: walks plugins/work/scripts/**\/*.js (skipping
+ * __tests__ and fixture folders) and fails when an identity-detection
+ * primitive appears outside lib/agent-identity.js and its sanctioned
+ * internal legs.
+ *
+ * Burn-down allowlist policy (mirrors .quality-exceptions):
+ *   - Every allowlist entry MUST currently match at least one forbidden
+ *     pattern — a stale entry fails the suite until it is removed.
+ *   - The allowlist may only SHRINK: MAX_ALLOWLIST_SIZE below may only be
+ *     decreased, never increased. Adding a new entry fails the size check.
+ *
+ * Run: node --test plugins/work/scripts/workflows/lib/__tests__/agent-identity-grep-guard.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// __tests__ → lib → workflows → scripts → work → plugins → repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..', '..', '..', '..');
+const SCAN_ROOT = path.join(REPO_ROOT, 'plugins', 'work', 'scripts');
+
+// ─── Forbidden identity primitives (line-level regexes) ─────────────────────
+
+const FORBIDDEN_PATTERNS = Object.freeze([
+  {
+    name: 'process.env.CLAUDE_CURRENT_AGENT',
+    re: /process\.env\.CLAUDE_CURRENT_AGENT/,
+    suggestion: 'use envAgentName() from lib/agent-identity',
+  },
+  {
+    name: '.agent_type',
+    re: /\.agent_type\b/,
+    suggestion: 'use payloadAgentName(hookData) / classifyIdentity() from lib/agent-identity',
+  },
+  {
+    name: '.agent_name',
+    re: /\.agent_name\b/,
+    suggestion: 'use payloadAgentName(hookData) / classifyIdentity() from lib/agent-identity',
+  },
+  {
+    name: '.subagent_type',
+    re: /\.subagent_type\b/,
+    suggestion: 'use dispatchTargetAgent(toolInput) from lib/agent-identity',
+  },
+  {
+    name: 'attributionAgent',
+    re: /\battributionAgent\b/,
+    suggestion: 'use classifyIdentity() from lib/agent-identity',
+  },
+  {
+    name: 'isSidechain',
+    re: /\bisSidechain\b/,
+    suggestion: 'use isSubagentContext() from lib/agent-identity',
+  },
+  {
+    name: 'readFileSync(transcript)',
+    re: /readFileSync\(.*transcript/,
+    suggestion: 'use classifyIdentity() / readInitialMarkers() from lib/agent-identity',
+  },
+]);
+
+// ─── Burn-down allowlist ────────────────────────────────────────────────────
+// { file, reason } — `file` is repo-root-relative (posix). A trailing '/'
+// marks a directory prefix (every file under it is covered).
+//
+// BURN-DOWN: this list may only shrink. Do NOT add entries — migrate the new
+// call site to lib/agent-identity.js instead.
+
+const LIB = 'plugins/work/scripts/workflows/lib';
+const WF = 'plugins/work/scripts/workflows';
+
+const ALLOWLIST = Object.freeze([
+  // ── Module boundary (the module itself + sanctioned internal legs) ──
+  { file: `${LIB}/agent-identity.js`, reason: 'module boundary — the identity module entry point' },
+  {
+    file: `${LIB}/agent-detection.js`,
+    reason: 'module boundary — re-export shim / sanctioned leg',
+  },
+  { file: `${LIB}/transcript-markers.js`, reason: 'module boundary — sanctioned internal leg' },
+  { file: `${LIB}/runtime/`, reason: 'module boundary — sanctioned internal legs (GH-696-locked)' },
+  // ── Excluded-with-reason consumers (spec.md migration manifest) ──
+  {
+    file: `${LIB}/hooks/policies/evidence-recorder.js`,
+    reason: 'label-only telemetry read (logged, not branched)',
+  },
+  {
+    file: `${LIB}/hooks/policies/hook-telemetry.js`,
+    reason: 'label-only telemetry snapshot (logged, not branched)',
+  },
+  {
+    file: `${WF}/work/hooks/capture-usage.js`,
+    reason: 'label-only usage-attribution read (logged, not branched)',
+  },
+  {
+    file: `${LIB}/hooks/policies/step-gate.js`,
+    reason: 'label-only command description for the gate log (logged, not branched)',
+  },
+  {
+    file: `${LIB}/hooks/policies/workflow-loop-rules.js`,
+    reason: 'label-only Task action-log label (logged, not branched)',
+  },
+  {
+    file: `${LIB}/phase-runner/create-phase-runner.js`,
+    reason: 'env label read; GH-763/GH-764 deletion pending — no new coupling',
+  },
+  {
+    file: `${WF}/work-implement/task-next.js`,
+    reason: 'env label read; GH-764 deletion-slated consumer',
+  },
+  {
+    file: `${WF}/work/hooks/work-require-implement.js`,
+    reason: 'dispatch-record history query over transcript, not self-identity',
+  },
+  {
+    file: `${WF}/work-implement/hooks/enforce-developer-detect.js`,
+    reason:
+      'dispatch-record history query over transcript (was a developer invoked), not self-identity',
+  },
+  {
+    file: `${LIB}/hooks/enforce-env-start-failure.js`,
+    reason: 'transcript read for tool output / user answer, not identity',
+  },
+  {
+    file: `${WF}/work/hooks/enforce-coverage-fix.js`,
+    reason: 'transcript read for recent tool output, not identity',
+  },
+]);
+
+// BURN-DOWN: may only DECREASE. Never raise this number — fix the code.
+const MAX_ALLOWLIST_SIZE = 15;
+
+// ─── Scanner ────────────────────────────────────────────────────────────────
+
+const SKIP_DIRS = new Set(['__tests__', '__fixtures__', 'fixtures', 'node_modules']);
+
+function isCommentLine(line) {
+  const t = line.trim();
+  return t.startsWith('//') || t.startsWith('*') || t.startsWith('/*');
+}
+
+/** Recursively collect .js files under `dir`, skipping test/fixture folders. */
+function collectJsFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIP_DIRS.has(entry.name)) collectJsFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function toRel(absFile, root) {
+  return path.relative(root, absFile).split(path.sep).join('/');
+}
+
+function isAllowlisted(relFile, allowlist) {
+  return allowlist.some((entry) =>
+    entry.file.endsWith('/') ? relFile.startsWith(entry.file) : relFile === entry.file
+  );
+}
+
+function formatViolation(v) {
+  return `${v.file}:${v.line} matches forbidden pattern [${v.pattern}] — ${v.suggestion}`;
+}
+
+/**
+ * Scan a tree for forbidden identity primitives.
+ * @returns {{ violations: Array<{file,line,pattern,suggestion,text}>,
+ *             staleEntries: string[] }}
+ *   violations  — non-allowlisted matches (relative paths against `relRoot`)
+ *   staleEntries — allowlist entries with zero live matches (burn-down)
+ */
+function scanTree(scanRoot, allowlist, relRoot = REPO_ROOT) {
+  const violations = [];
+  const liveEntries = new Set();
+
+  for (const absFile of collectJsFiles(scanRoot)) {
+    const relFile = toRel(absFile, relRoot);
+    const lines = fs.readFileSync(absFile, 'utf8').split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = lines[i];
+      if (isCommentLine(line)) continue;
+      for (const pattern of FORBIDDEN_PATTERNS) {
+        if (!pattern.re.test(line)) continue;
+        const entry = allowlist.find((e) =>
+          e.file.endsWith('/') ? relFile.startsWith(e.file) : relFile === e.file
+        );
+        if (entry) {
+          liveEntries.add(entry.file);
+        } else {
+          violations.push({
+            file: relFile,
+            line: i + 1,
+            pattern: pattern.name,
+            suggestion: pattern.suggestion,
+            text: line.trim(),
+          });
+        }
+      }
+    }
+  }
+
+  const staleEntries = allowlist.map((e) => e.file).filter((f) => !liveEntries.has(f));
+  return { violations, staleEntries };
+}
+
+// ─── Suite ──────────────────────────────────────────────────────────────────
+
+function withTempTree(files, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'grep-guard-'));
+  try {
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('agent-identity grep-guard — walker unit behavior', () => {
+  it('reports a synthetic violation with file, line, and pattern', () => {
+    withTempTree(
+      { 'hooks/bad.js': "'use strict';\nconst who = process.env.CLAUDE_CURRENT_AGENT;\n" },
+      (dir) => {
+        const { violations } = scanTree(dir, [], dir);
+        assert.equal(violations.length, 1);
+        assert.equal(violations[0].file, 'hooks/bad.js');
+        assert.equal(violations[0].line, 2);
+        assert.equal(violations[0].pattern, 'process.env.CLAUDE_CURRENT_AGENT');
+      }
+    );
+  });
+
+  it('detects every forbidden pattern class', () => {
+    const samples = [
+      'const a = process.env.CLAUDE_CURRENT_AGENT;',
+      'const b = hookData.agent_type;',
+      'const c = hookData.agent_name;',
+      'const d = toolInput.subagent_type;',
+      'const e = attributionAgent(x);',
+      'if (entry.isSidechain) {}',
+      "const f = fs.readFileSync(transcriptPath, 'utf8');",
+    ];
+    withTempTree({ 'all.js': samples.join('\n') }, (dir) => {
+      const { violations } = scanTree(dir, [], dir);
+      assert.equal(violations.length, FORBIDDEN_PATTERNS.length);
+    });
+  });
+
+  it('skips __tests__ and fixture directories', () => {
+    withTempTree(
+      {
+        '__tests__/t.js': 'const x = hookData.agent_type;',
+        'fixtures/f.js': 'const x = hookData.agent_type;',
+        '__fixtures__/g.js': 'const x = hookData.agent_type;',
+      },
+      (dir) => {
+        const { violations } = scanTree(dir, [], dir);
+        assert.deepEqual(violations, []);
+      }
+    );
+  });
+
+  it('ignores pure comment lines (mentions are not detection)', () => {
+    withTempTree(
+      { 'ok.js': '// hookData.tool_input.subagent_type names the target\nconst x = 1;\n' },
+      (dir) => {
+        const { violations } = scanTree(dir, [], dir);
+        assert.deepEqual(violations, []);
+      }
+    );
+  });
+
+  it('failure message names file, line, pattern, and the accessor to use instead', () => {
+    withTempTree({ 'bad.js': 'const who = process.env.CLAUDE_CURRENT_AGENT;\n' }, (dir) => {
+      const { violations } = scanTree(dir, [], dir);
+      const msg = formatViolation(violations[0]);
+      assert.match(msg, /bad\.js/);
+      assert.match(msg, /:1\b/);
+      assert.match(msg, /process\.env\.CLAUDE_CURRENT_AGENT/);
+      assert.match(msg, /use envAgentName\(\) from lib\/agent-identity/);
+    });
+  });
+
+  it('reports a stale allowlist entry (file with no live match) for removal', () => {
+    withTempTree({ 'clean.js': 'const x = 1;\n' }, (dir) => {
+      const stale = [{ file: 'clean.js', reason: 'no longer needed' }];
+      const { staleEntries } = scanTree(dir, stale, dir);
+      assert.deepEqual(staleEntries, ['clean.js']);
+    });
+  });
+});
+
+describe('agent-identity grep-guard — real tree', () => {
+  const result = scanTree(SCAN_ROOT, ALLOWLIST, REPO_ROOT);
+
+  it('has zero identity primitives outside the module boundary + allowlist', () => {
+    const report = result.violations.map(formatViolation).join('\n');
+    assert.deepEqual(
+      result.violations,
+      [],
+      `Inline identity heuristics found outside lib/agent-identity.js:\n${report}\n` +
+        'Do NOT add these files to the allowlist (burn-down: it may only shrink) — ' +
+        'migrate the call site to lib/agent-identity.js instead.'
+    );
+  });
+
+  it('every allowlist entry is live — stale entries must be removed (burn-down)', () => {
+    assert.deepEqual(
+      result.staleEntries,
+      [],
+      `Stale allowlist entries (no forbidden pattern matches anymore): ` +
+        `${result.staleEntries.join(', ')}. Remove them — the allowlist may only shrink.`
+    );
+  });
+
+  it('the allowlist may only shrink (size is capped at the burn-down maximum)', () => {
+    assert.ok(
+      ALLOWLIST.length <= MAX_ALLOWLIST_SIZE,
+      `Allowlist grew to ${ALLOWLIST.length} entries (max ${MAX_ALLOWLIST_SIZE}). ` +
+        'The allowlist may only shrink — migrate the new consumer to lib/agent-identity.js. ' +
+        'Never raise MAX_ALLOWLIST_SIZE.'
+    );
+    assert.equal(
+      ALLOWLIST.length,
+      new Set(ALLOWLIST.map((e) => e.file)).size,
+      'Duplicate allowlist entries'
+    );
+  });
+
+  it('every allowlist entry carries a one-line reason', () => {
+    for (const entry of ALLOWLIST) {
+      assert.ok(
+        typeof entry.reason === 'string' && entry.reason.length > 0 && !entry.reason.includes('\n'),
+        `Allowlist entry ${entry.file} must have a one-line reason`
+      );
+    }
+  });
+
+  it('session-guard and scope-protection files are scanned, not allowlisted', () => {
+    const covered = [
+      `${LIB}/hooks/session-guard.js`,
+      `${LIB}/hooks/session-guard/hook-handlers.js`,
+      `${LIB}/hooks/policies/scope-protection.js`,
+    ];
+    for (const rel of covered) {
+      assert.ok(fs.existsSync(path.join(REPO_ROOT, rel)), `Expected scanned file to exist: ${rel}`);
+      assert.ok(!isAllowlisted(rel, ALLOWLIST), `${rel} must NOT be allowlisted`);
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-identity-matrix.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-identity-matrix.test.js
@@ -1,0 +1,483 @@
+'use strict';
+
+/**
+ * Table-driven identity-source × decision matrix for lib/agent-identity.js
+ * (GH-767, spec "P0 #4").
+ *
+ * Rows = the six identity sources (orchestrator main session, work agent
+ * persona payload, Task-dispatched subagent transcript, headless -p CLI,
+ * codex rollout, env-only). Columns = the hook decisions
+ * (isRunningInAgent / isDispatchedAgentContext / payloadAgentName).
+ * One it() per matrix cell, declared in a data table iterated by the suite.
+ *
+ * Fixtures follow the writeTranscript tmpdir pattern from
+ * agent-detection.test.js.
+ *
+ * Run: node --test plugins/work/scripts/workflows/lib/__tests__/agent-identity-matrix.test.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Lazy-tolerant load: while lib/agent-identity.js does not exist yet (RED),
+// every test still gets collected and fails on the assertion below instead of
+// the whole suite crashing at load time.
+let identity = null;
+try {
+  identity = require('../agent-identity');
+} catch {
+  identity = null;
+}
+
+function api(name) {
+  assert.ok(identity, 'lib/agent-identity.js is missing — the entry point does not exist yet');
+  const fn = identity[name];
+  assert.equal(typeof fn, 'function', `agent-identity must export ${name} as a function`);
+  return fn;
+}
+
+const isRunningInAgent = (...args) => api('isRunningInAgent')(...args);
+const isDispatchedAgentContext = (...args) => api('isDispatchedAgentContext')(...args);
+const payloadAgentName = (...args) => api('payloadAgentName')(...args);
+const dispatchTargetAgent = (...args) => api('dispatchTargetAgent')(...args);
+const envAgentName = (...args) => api('envAgentName')(...args);
+const classifyIdentity = (...args) => api('classifyIdentity')(...args);
+const activeAgentDetectionPayload = (...args) => api('activeAgentDetectionPayload')(...args);
+
+// Transcripts live in a private mode-0700 tmpdir (unpredictable name) so a
+// predictable filename cannot be exploited via a symlink/race attack.
+const TRANSCRIPT_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-identity-'));
+process.on('exit', () => {
+  try {
+    fs.rmSync(TRANSCRIPT_DIR, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup */
+  }
+});
+
+// Build a claude JSONL transcript file from line objects; returns its path.
+function writeTranscript(lines) {
+  const tmp = path.join(
+    TRANSCRIPT_DIR,
+    `matrix-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+  );
+  fs.writeFileSync(tmp, `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`);
+  return tmp;
+}
+
+// Build a codex rollout transcript (session_meta + response_item records).
+function writeRollout(records) {
+  const tmp = path.join(
+    TRANSCRIPT_DIR,
+    `rollout-${process.pid}-${Math.random().toString(36).slice(2)}.jsonl`
+  );
+  const meta = {
+    type: 'session_meta',
+    payload: { id: 's-1', cwd: '/tmp/x', timestamp: '2026-07-17T00:00:00Z' },
+  };
+  fs.writeFileSync(tmp, [meta, ...records].map((r) => JSON.stringify(r)).join('\n'));
+  return tmp;
+}
+
+function spawnAgentCall(callId, agentType) {
+  return {
+    type: 'response_item',
+    payload: {
+      type: 'function_call',
+      name: 'spawn_agent',
+      call_id: callId,
+      arguments: JSON.stringify({ agent_type: agentType, prompt: 'do the work' }),
+    },
+  };
+}
+
+// ─── Env hygiene: every test runs with a clean identity env ─────────────────
+
+const SAVED_ENV_KEYS = ['CLAUDE_CURRENT_AGENT', 'CLAUDE_AGENT_TYPE', 'ENFORCE_HOOK_DEBUG'];
+const savedEnv = {};
+
+beforeEach(() => {
+  for (const key of SAVED_ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of SAVED_ENV_KEYS) {
+    if (savedEnv[key] !== undefined) process.env[key] = savedEnv[key];
+    else delete process.env[key];
+  }
+});
+
+// ─── 1.1 Module surface: exports and accessor payload shapes ────────────────
+
+describe('agent-identity module surface', () => {
+  const EXPECTED_EXPORTS = [
+    // re-exports of the existing detection legs
+    'isRunningInAgent',
+    'isDispatchedAgentContext',
+    'isSubagentContext',
+    'isSubagentFromInitialPrompt',
+    'normalizeAgentName',
+    'matchesAlias',
+    'readInitialMarkers',
+    // new accessors
+    'payloadAgentName',
+    'dispatchTargetAgent',
+    'envAgentName',
+    'classifyIdentity',
+    'activeAgentDetectionPayload',
+  ];
+
+  for (const name of EXPECTED_EXPORTS) {
+    it(`exports ${name} as a function`, () => {
+      assert.ok(identity, 'lib/agent-identity.js is missing — the entry point does not exist yet');
+      assert.equal(typeof identity[name], 'function', `${name} must be exported as a function`);
+    });
+  }
+});
+
+describe('Payload agent_type is the highest-precedence self-identity signal', () => {
+  it('payloadAgentName reads agent_type first, normalized', () => {
+    assert.equal(
+      payloadAgentName({ agent_type: 'Work-Workflow:Quality-Checker' }),
+      'quality-checker'
+    );
+  });
+
+  it('payloadAgentName prefers agent_type over agent_name and subagent_type', () => {
+    assert.equal(
+      payloadAgentName({
+        agent_type: 'quality-checker',
+        agent_name: 'pr-generator',
+        subagent_type: 'commit-writer',
+      }),
+      'quality-checker'
+    );
+  });
+
+  it('payloadAgentName falls back to legacy agent_name', () => {
+    assert.equal(payloadAgentName({ agent_name: 'work-workflow:pr-generator' }), 'pr-generator');
+  });
+
+  it('payloadAgentName falls back to top-level subagent_type last', () => {
+    assert.equal(payloadAgentName({ subagent_type: 'Commit-Writer' }), 'commit-writer');
+  });
+
+  it("payloadAgentName returns '' for an empty payload", () => {
+    assert.equal(payloadAgentName({}), '');
+  });
+
+  it("payloadAgentName returns '' for null/undefined payloads", () => {
+    assert.equal(payloadAgentName(null), '');
+    assert.equal(payloadAgentName(undefined), '');
+  });
+
+  it("payloadAgentName returns '' for malformed (non-string) identity fields", () => {
+    assert.equal(payloadAgentName({ agent_type: 42 }), '');
+    assert.equal(payloadAgentName({ agent_type: { nested: true } }), '');
+  });
+
+  it('payload agent_type wins even when env names a different agent', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'pr-generator';
+    const result = classifyIdentity(null, ['quality-checker'], {
+      agent_type: 'quality-checker',
+    });
+    assert.equal(result.decision, true);
+    assert.equal(result.signal, 'payload');
+  });
+});
+
+describe('Dispatch target is never conflated with self-identity', () => {
+  it('dispatchTargetAgent returns the normalized subagent_type of the tool input', () => {
+    assert.equal(
+      dispatchTargetAgent({ subagent_type: 'Work-Workflow:Quality-Checker' }),
+      'quality-checker'
+    );
+  });
+
+  it("dispatchTargetAgent returns '' for null/missing/malformed tool input", () => {
+    assert.equal(dispatchTargetAgent(null), '');
+    assert.equal(dispatchTargetAgent(undefined), '');
+    assert.equal(dispatchTargetAgent({}), '');
+    assert.equal(dispatchTargetAgent({ subagent_type: 7 }), '');
+  });
+
+  it('payloadAgentName ignores tool_input.subagent_type (dispatch target, not self)', () => {
+    assert.equal(
+      payloadAgentName({ tool_name: 'Task', tool_input: { subagent_type: 'quality-checker' } }),
+      ''
+    );
+  });
+
+  it('activeAgentDetectionPayload strips tool_input.subagent_type', () => {
+    const hookData = {
+      tool_name: 'Bash',
+      tool_input: { subagent_type: 'quality-checker', command: 'ls' },
+      transcript_path: '/tmp/nope.jsonl',
+    };
+    const stripped = activeAgentDetectionPayload(hookData);
+    assert.equal(stripped.tool_input.subagent_type, undefined);
+    assert.equal(stripped.tool_input.command, 'ls');
+    // original payload untouched
+    assert.equal(hookData.tool_input.subagent_type, 'quality-checker');
+  });
+
+  it('activeAgentDetectionPayload returns the payload unchanged when no subagent_type', () => {
+    const hookData = { tool_name: 'Bash', tool_input: { command: 'ls' } };
+    assert.equal(activeAgentDetectionPayload(hookData), hookData);
+  });
+
+  it('a parent dispatching an agent is NOT identified as that agent', () => {
+    const hookData = { tool_name: 'Task', tool_input: { subagent_type: 'quality-checker' } };
+    assert.equal(
+      isRunningInAgent(null, ['quality-checker'], activeAgentDetectionPayload(hookData)),
+      false
+    );
+  });
+});
+
+describe('envAgentName', () => {
+  it('returns the normalized CLAUDE_CURRENT_AGENT value', () => {
+    process.env.CLAUDE_CURRENT_AGENT = 'Work-Workflow:Quality-Checker';
+    assert.equal(envAgentName(), 'quality-checker');
+  });
+
+  it("returns '' when CLAUDE_CURRENT_AGENT is unset", () => {
+    assert.equal(envAgentName(), '');
+  });
+});
+
+// ─── 1.2 The identity-source × decision matrix (spec "P0 #4") ───────────────
+
+const MATCH_ALIASES = ['quality-checker'];
+const MISMATCH_ALIASES = ['pr-generator'];
+
+/**
+ * Six identity sources. Each row declares fixture builders and the expected
+ * truth value for every decision column (spec "P0 #4" table).
+ */
+const MATRIX = [
+  {
+    source: 'Orchestrator main session yields the null identity everywhere',
+    fixture: () => ({ transcriptPath: null, hookData: {} }),
+    expected: {
+      isRunningInAgent: false,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: false,
+      payloadAgentName: '',
+      classifySignal: 'none',
+    },
+  },
+  {
+    source: 'Payload agent_type is the highest-precedence self-identity signal',
+    fixture: () => ({
+      transcriptPath: null,
+      hookData: { agent_type: 'work-workflow:quality-checker' },
+    }),
+    expected: {
+      isRunningInAgent: true,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: true,
+      payloadAgentName: 'quality-checker',
+      classifySignal: 'payload',
+    },
+  },
+  {
+    source: 'Task-dispatched subagent identified by attributionAgent marker',
+    fixture: () => ({
+      transcriptPath: writeTranscript([
+        {
+          type: 'user',
+          isSidechain: true,
+          attributionAgent: 'quality-checker',
+          message: { role: 'user', content: 'Run the quality checks for GH-767.' },
+        },
+      ]),
+      hookData: {},
+    }),
+    expected: {
+      isRunningInAgent: true,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: true,
+      payloadAgentName: '',
+      classifySignal: 'structural-marker',
+    },
+  },
+  {
+    source: 'Headless -p CLI transcript whose prompt mentions agent names',
+    fixture: () => ({
+      transcriptPath: writeTranscript([
+        {
+          type: 'user',
+          message: {
+            role: 'user',
+            content: 'use the quality-checker agent and then the pr-generator agent',
+          },
+        },
+      ]),
+      hookData: {},
+    }),
+    expected: {
+      isRunningInAgent: false,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: false,
+      payloadAgentName: '',
+      classifySignal: 'none',
+    },
+  },
+  {
+    source: 'Codex rollout transcript routes through the dual-runtime leg',
+    fixture: () => ({
+      transcriptPath: writeRollout([spawnAgentCall('c1', 'quality-checker')]),
+      hookData: {},
+    }),
+    expected: {
+      isRunningInAgent: true,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: false,
+      payloadAgentName: '',
+      classifySignal: 'codex-rollout',
+    },
+  },
+  {
+    source: 'Env-only CLAUDE_CURRENT_AGENT (documented legacy, spoofable)',
+    env: { CLAUDE_CURRENT_AGENT: 'work-workflow:quality-checker' },
+    fixture: () => ({ transcriptPath: null, hookData: {} }),
+    expected: {
+      isRunningInAgent: true,
+      isRunningInAgentMismatch: false,
+      isDispatchedAgentContext: true,
+      payloadAgentName: '',
+      classifySignal: 'env',
+    },
+  },
+];
+
+function applyRowEnv(row) {
+  for (const [key, value] of Object.entries(row.env || {})) {
+    process.env[key] = value;
+  }
+}
+
+describe('identity-source × decision matrix', () => {
+  for (const row of MATRIX) {
+    describe(row.source, () => {
+      it(`isRunningInAgent(quality-checker) → ${row.expected.isRunningInAgent}`, () => {
+        applyRowEnv(row);
+        const { transcriptPath, hookData } = row.fixture();
+        assert.equal(
+          isRunningInAgent(transcriptPath, MATCH_ALIASES, hookData),
+          row.expected.isRunningInAgent
+        );
+      });
+
+      it(`isRunningInAgent(pr-generator alias mismatch) → ${row.expected.isRunningInAgentMismatch}`, () => {
+        applyRowEnv(row);
+        const { transcriptPath, hookData } = row.fixture();
+        assert.equal(
+          isRunningInAgent(transcriptPath, MISMATCH_ALIASES, hookData),
+          row.expected.isRunningInAgentMismatch
+        );
+      });
+
+      it(`isDispatchedAgentContext → ${row.expected.isDispatchedAgentContext}`, () => {
+        applyRowEnv(row);
+        const { transcriptPath, hookData } = row.fixture();
+        assert.equal(
+          isDispatchedAgentContext(transcriptPath, hookData),
+          row.expected.isDispatchedAgentContext
+        );
+      });
+
+      it(`payloadAgentName → '${row.expected.payloadAgentName}'`, () => {
+        applyRowEnv(row);
+        const { hookData } = row.fixture();
+        assert.equal(payloadAgentName(hookData), row.expected.payloadAgentName);
+      });
+    });
+  }
+});
+
+// ─── 1.3 classifyIdentity: deciding-signal shape + debug observability ──────
+
+function captureStderr(fn) {
+  const lines = [];
+  const original = process.stderr.write;
+  process.stderr.write = (chunk, ...rest) => {
+    lines.push(String(chunk));
+    return typeof original === 'function' ? true : original.call(process.stderr, chunk, ...rest);
+  };
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return lines.filter((l) => l.startsWith('[agent-identity]'));
+}
+
+describe('classifyIdentity — deciding signal per matrix row', () => {
+  for (const row of MATRIX) {
+    it(`${row.source}: { decision: ${row.expected.isRunningInAgent}, signal: '${row.expected.classifySignal}' }`, () => {
+      applyRowEnv(row);
+      const { transcriptPath, hookData } = row.fixture();
+      const result = classifyIdentity(transcriptPath, MATCH_ALIASES, hookData);
+      assert.equal(typeof result, 'object');
+      assert.equal(result.decision, row.expected.isRunningInAgent);
+      assert.equal(result.signal, row.expected.classifySignal);
+    });
+  }
+
+  it('with ENFORCE_HOOK_DEBUG=1 each classification emits exactly one [agent-identity] stderr line', () => {
+    for (const row of MATRIX) {
+      applyRowEnv(row);
+      const { transcriptPath, hookData } = row.fixture();
+      process.env.ENFORCE_HOOK_DEBUG = '1';
+      const debugLines = captureStderr(() => {
+        classifyIdentity(transcriptPath, MATCH_ALIASES, hookData);
+      });
+      delete process.env.ENFORCE_HOOK_DEBUG;
+      assert.equal(
+        debugLines.length,
+        1,
+        `${row.source}: expected exactly one [agent-identity] line, got ${debugLines.length}`
+      );
+      assert.match(
+        debugLines[0],
+        new RegExp(`^\\[agent-identity\\] ${row.expected.classifySignal}:`),
+        `${row.source}: line must name the deciding signal`
+      );
+    }
+  });
+
+  it('without ENFORCE_HOOK_DEBUG the [agent-identity] channel is silent', () => {
+    for (const row of MATRIX) {
+      applyRowEnv(row);
+      const { transcriptPath, hookData } = row.fixture();
+      const debugLines = captureStderr(() => {
+        classifyIdentity(transcriptPath, MATCH_ALIASES, hookData);
+      });
+      assert.equal(debugLines.length, 0, `${row.source}: expected silence without the env var`);
+      // Reset env between rows (env-only row sets CLAUDE_CURRENT_AGENT).
+      delete process.env.CLAUDE_CURRENT_AGENT;
+    }
+  });
+});
+
+// ─── 1.4 Hook-author pointer paragraph in plugins/work/CLAUDE.md ────────────
+
+describe('hook-author pointer paragraph in plugins/work/CLAUDE.md', () => {
+  const claudeMdPath = path.resolve(__dirname, '..', '..', '..', '..', 'CLAUDE.md');
+
+  it('CLAUDE.md points hook authors at the agent-identity module contract', () => {
+    const content = fs.readFileSync(claudeMdPath, 'utf8');
+    assert.match(content, /agent-identity/, 'CLAUDE.md must mention agent-identity');
+    assert.match(content, /payloadAgentName/, 'paragraph must name payloadAgentName');
+    assert.match(content, /dispatchTargetAgent/, 'paragraph must name dispatchTargetAgent');
+    assert.match(content, /envAgentName/, 'paragraph must name envAgentName');
+  });
+});

--- a/plugins/work/scripts/workflows/lib/__tests__/agent-identity-matrix.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/agent-identity-matrix.test.js
@@ -192,6 +192,32 @@ describe('Payload agent_type is the highest-precedence self-identity signal', ()
   });
 });
 
+describe('classifyIdentity verdict matches isRunningInAgent exactly (GH-767 review)', () => {
+  // The observability classifier must never report a verdict its target
+  // function wouldn't. These pin the two payload-leg divergences flagged in
+  // review: top-level agent_name (IGNORED by the decision walk) and
+  // tool_input.subagent_type (HONORED by the decision walk).
+  it('top-level agent_name alone does NOT identify (parity with isRunningInAgent=false)', () => {
+    const hookData = { agent_name: 'quality-checker' };
+    assert.equal(isRunningInAgent(null, ['quality-checker'], hookData), false);
+    assert.equal(classifyIdentity(null, ['quality-checker'], hookData).decision, false);
+  });
+
+  it('tool_input.subagent_type match identifies via the payload signal (parity with isRunningInAgent=true)', () => {
+    const hookData = { tool_input: { subagent_type: 'quality-checker' } };
+    assert.equal(isRunningInAgent(null, ['quality-checker'], hookData), true);
+    const result = classifyIdentity(null, ['quality-checker'], hookData);
+    assert.equal(result.decision, true);
+    assert.equal(result.signal, 'payload');
+  });
+
+  it('agent_type match identifies via the payload signal (parity with isRunningInAgent=true)', () => {
+    const hookData = { agent_type: 'quality-checker' };
+    assert.equal(isRunningInAgent(null, ['quality-checker'], hookData), true);
+    assert.equal(classifyIdentity(null, ['quality-checker'], hookData).signal, 'payload');
+  });
+});
+
 describe('Dispatch target is never conflated with self-identity', () => {
   it('dispatchTargetAgent returns the normalized subagent_type of the tool input', () => {
     assert.equal(

--- a/plugins/work/scripts/workflows/lib/agent-detection.js
+++ b/plugins/work/scripts/workflows/lib/agent-detection.js
@@ -1,6 +1,12 @@
 /**
  * Shared agent detection utilities for Claude Code hooks.
  *
+ * INTERNAL LEG — new consumers import `lib/agent-identity.js` (GH-767), the
+ * canonical entry point that re-exports this module's predicates alongside
+ * the payload/env accessors and documents the full identity contract. This
+ * file stays byte-compatible in logic; the entry point requires this leg,
+ * so this leg must never require the entry point (cycle-free by design).
+ *
  * Provides reliable detection of whether code is executing inside
  * a specific subagent context, using multiple detection strategies.
  */
@@ -318,6 +324,8 @@ module.exports = {
   isRunningInAgent,
   isSubagentFromTranscript,
   isSubagentFromInitialPrompt,
+  isAgentFromFrontmatter,
   isDispatchedAgentContext, // GH-695 — lives in ./transcript-markers, re-exported
   normalizeAgentName,
+  matchesAlias,
 };

--- a/plugins/work/scripts/workflows/lib/agent-identity.js
+++ b/plugins/work/scripts/workflows/lib/agent-identity.js
@@ -170,11 +170,39 @@ function activeAgentDetectionPayload(hookData) {
  * (payload → env → codex rollout → structural markers → task scan →
  * frontmatter) but reports WHICH signal decided.
  */
-function classifySignal(transcriptPath, agentAliases, hookData) {
-  const fromPayload = payloadAgentName(hookData);
-  if (fromPayload && matchesAlias(fromPayload, agentAliases)) {
-    return { decision: true, signal: SIGNALS.PAYLOAD, detail: `agent=${fromPayload}` };
+/**
+ * Payload leg of the classify walk — mirrors agentFromHookData
+ * (isRunningInAgent's first step) EXACTLY: hookData.agent_type, then
+ * hookData.tool_input.subagent_type. NOT payloadAgentName: that self-identity
+ * accessor also reads top-level agent_name (which the decision walk ignores)
+ * and excludes tool_input.subagent_type (which the decision walk honors), so
+ * reusing it would let this observability classifier report a verdict that
+ * diverges from isRunningInAgent. Returns a signal object on a match, else
+ * null to fall through.
+ */
+function classifyPayloadSignal(hookData, agentAliases) {
+  const agentType = hookData?.agent_type;
+  if (matchesAlias(agentType, agentAliases)) {
+    return {
+      decision: true,
+      signal: SIGNALS.PAYLOAD,
+      detail: `agent_type=${normalizeAgentName(agentType)}`,
+    };
   }
+  const dispatchTarget = hookData?.tool_input?.subagent_type;
+  if (matchesAlias(dispatchTarget, agentAliases)) {
+    return {
+      decision: true,
+      signal: SIGNALS.PAYLOAD,
+      detail: `tool_input.subagent_type=${normalizeAgentName(dispatchTarget)}`,
+    };
+  }
+  return null;
+}
+
+function classifySignal(transcriptPath, agentAliases, hookData) {
+  const fromPayload = classifyPayloadSignal(hookData, agentAliases);
+  if (fromPayload) return fromPayload;
 
   const fromEnv = envAgentName();
   if (fromEnv && matchesAlias(fromEnv, agentAliases)) {

--- a/plugins/work/scripts/workflows/lib/agent-identity.js
+++ b/plugins/work/scripts/workflows/lib/agent-identity.js
@@ -1,0 +1,246 @@
+/**
+ * agent-identity.js — the ONE canonical entry point for agent-identity
+ * questions in hooks (GH-767).
+ *
+ * New hooks import THIS module. Never probe `process.env.CLAUDE_CURRENT_AGENT`,
+ * payload `agent_type`/`agent_name`/`subagent_type`, or transcript markers
+ * directly — the grep-guard test rejects new inline reads.
+ *
+ * ## Inputs (signal precedence, highest trust first)
+ *   1. Hook payload (raw stdin JSON) — `agent_type` is the documented
+ *      self-identity field; codex sets no CLAUDE_* env vars, so payload-first
+ *      is the dual-runtime rule (design C12).
+ *   2. Transcript structural markers — Task-dispatch records
+ *      (`attributionAgent` / `isSidechain`), active Task/spawn_agent scans,
+ *      legacy frontmatter. Codex rollouts route through the dual-runtime
+ *      reader (`runtime/transcript.js detectAgentContext`).
+ *   3. Env (`CLAUDE_CURRENT_AGENT`) — spoofable, lowest trust (see
+ *      `envAgentName`).
+ *
+ * ## The six identity questions (distinct — never conflate them)
+ *   1. `isRunningInAgent(transcriptPath, aliases, hookData)` — "am I agent X?"
+ *      Walk: payload → env → codex rollout → structural initial-prompt
+ *      markers → active Task scan → legacy frontmatter.
+ *   2. `isDispatchedAgentContext(transcriptPath, hookData)` — "am I ANY
+ *      dispatched agent?" (GH-695). Fail-open false; DELIBERATELY
+ *      env-sensitive: a leaked env var only blocks a terminal bypass with a
+ *      message naming the leaked var.
+ *   3. `isSubagentContext(evt)` — canonical-event leg (`runtime/payload.js`),
+ *      DELIBERATELY env-BLIND (GH-696 / PR #718): an env leak here would
+ *      silently mute auto-advance in a main session — a liveness failure
+ *      with no error message. Questions 2 and 3 differ in fail direction on
+ *      purpose; DO NOT merge them.
+ *   4. `payloadAgentName(hookData)` — raw self-identity string from the
+ *      payload (`agent_type || agent_name || subagent_type`), normalized.
+ *   5. `dispatchTargetAgent(toolInput)` — the agent being DISPATCHED
+ *      (`tool_input.subagent_type`). A dispatch target is NEVER self-identity
+ *      (the agent-hook-dispatcher false-match bug class).
+ *   6. `envAgentName()` — `CLAUDE_CURRENT_AGENT` probe. Spoofable: any
+ *      process can export it, and tmux global env leaks it across sessions.
+ *      Lowest trust; never use it as the sole gate for anything
+ *      security-relevant.
+ *
+ * ## The #665 rule (prohibition)
+ * Name-substring matching against user prose is only permitted inside a
+ * transcript POSITIVELY identified as a sidechain (`isSidechain` /
+ * `attributionAgent` markers). Never in main-session text, never in command
+ * text: a main session whose prompt merely says "use the commit-writer
+ * agent" must not be classified as commit-writer (GH-665 bricked-session
+ * incident class).
+ *
+ * ## Fail directions
+ * All accessors fail open: read/parse errors → `false` / `''` (established
+ * hook convention). `isDispatchedAgentContext` fail-open false per GH-695;
+ * `isSubagentContext` env-blind per GH-696 — preserved exactly, see above.
+ *
+ * ## Observability
+ * `classifyIdentity()` reports the deciding signal as `{ decision, signal }`
+ * and, when `ENFORCE_HOOK_DEBUG` is set, logs exactly one
+ * `[agent-identity] <signal>: <detail>` line to stderr.
+ *
+ * Internal legs (required, never re-implemented here):
+ *   - ./agent-detection.js — claude scanning leg (characterization-locked)
+ *   - ./transcript-markers.js — structural marker helpers + GH-695 predicate
+ *   - ./runtime/transcript.js — dual-format transcript reader (locked)
+ *   - ./runtime/payload.js — canonical-event leg (GH-696-locked)
+ */
+
+const {
+  isRunningInAgent,
+  isSubagentFromTranscript,
+  isSubagentFromInitialPrompt,
+  isDispatchedAgentContext,
+  isAgentFromFrontmatter,
+  normalizeAgentName,
+  matchesAlias,
+} = require('./agent-detection');
+const { readInitialMarkers } = require('./transcript-markers');
+const { sniffFormat, detectAgentContext } = require('./runtime/transcript');
+const { isSubagentContext } = require('./runtime/payload');
+
+/**
+ * Deciding-signal names, in precedence order. Keep in sync with the
+ * precedence walk in `classifyIdentity()` and the JSDoc header above.
+ */
+const SIGNALS = Object.freeze({
+  PAYLOAD: 'payload',
+  ENV: 'env',
+  CODEX_ROLLOUT: 'codex-rollout',
+  STRUCTURAL_MARKER: 'structural-marker',
+  TASK_SCAN: 'task-scan',
+  FRONTMATTER: 'frontmatter',
+  NONE: 'none',
+});
+
+function debugLog(signal, detail) {
+  if (process.env.ENFORCE_HOOK_DEBUG) {
+    process.stderr.write(`[agent-identity] ${signal}: ${detail}\n`);
+  }
+}
+
+/**
+ * Question 4 — raw self-identity name from the hook payload, normalized.
+ * Fallback order `agent_type || agent_name || subagent_type` (top-level
+ * fields only — `tool_input.subagent_type` is a dispatch TARGET, see
+ * `dispatchTargetAgent`). Non-string/missing fields are skipped; `''` on
+ * any error.
+ */
+function payloadAgentName(hookData) {
+  try {
+    if (!hookData || typeof hookData !== 'object') return '';
+    const raw = [hookData.agent_type, hookData.agent_name, hookData.subagent_type].find(
+      (value) => typeof value === 'string' && value !== ''
+    );
+    return raw ? normalizeAgentName(raw) : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Question 5 — the agent being DISPATCHED by a Task/Agent tool call
+ * (`tool_input.subagent_type`), normalized. Never self-identity: the parent
+ * making the Task call is NOT the target agent. `''` on error.
+ */
+function dispatchTargetAgent(toolInput) {
+  try {
+    const raw = toolInput && typeof toolInput === 'object' ? toolInput.subagent_type : null;
+    return typeof raw === 'string' && raw !== '' ? normalizeAgentName(raw) : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Question 6 — the `CLAUDE_CURRENT_AGENT` env probe, normalized.
+ * SPOOFABLE and leak-prone (tmux global env): lowest-trust signal, for
+ * legacy claude flows only. `''` when unset.
+ */
+function envAgentName() {
+  try {
+    const raw = process.env.CLAUDE_CURRENT_AGENT;
+    return typeof raw === 'string' && raw !== '' ? normalizeAgentName(raw) : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Dispatcher helper: a copy of the hook payload safe to feed to
+ * self-identity detection. Strips `tool_input.subagent_type` (a dispatch
+ * TARGET) so a non-Task tool that happens to carry the field can never make
+ * the parent look like the target agent (extracted from
+ * agent-hook-dispatcher.js). Returns the payload unchanged when there is
+ * nothing to strip; never mutates the input.
+ */
+function activeAgentDetectionPayload(hookData) {
+  try {
+    if (!hookData || typeof hookData !== 'object') return hookData;
+    if (hookData.tool_input && hookData.tool_input.subagent_type) {
+      return { ...hookData, tool_input: { ...hookData.tool_input, subagent_type: undefined } };
+    }
+    return hookData;
+  } catch {
+    return hookData;
+  }
+}
+
+/**
+ * Precedence walk for classifyIdentity — mirrors isRunningInAgent's order
+ * (payload → env → codex rollout → structural markers → task scan →
+ * frontmatter) but reports WHICH signal decided.
+ */
+function classifySignal(transcriptPath, agentAliases, hookData) {
+  const fromPayload = payloadAgentName(hookData);
+  if (fromPayload && matchesAlias(fromPayload, agentAliases)) {
+    return { decision: true, signal: SIGNALS.PAYLOAD, detail: `agent=${fromPayload}` };
+  }
+
+  const fromEnv = envAgentName();
+  if (fromEnv && matchesAlias(fromEnv, agentAliases)) {
+    return { decision: true, signal: SIGNALS.ENV, detail: `CLAUDE_CURRENT_AGENT=${fromEnv}` };
+  }
+
+  if (transcriptPath && sniffFormat(transcriptPath) === 'codex') {
+    const decision = detectAgentContext(transcriptPath, agentAliases);
+    return {
+      decision,
+      signal: SIGNALS.CODEX_ROLLOUT,
+      detail: `spawn_agent dispatch scan → ${decision}`,
+    };
+  }
+
+  if (isSubagentFromInitialPrompt(transcriptPath, agentAliases)) {
+    return { decision: true, signal: SIGNALS.STRUCTURAL_MARKER, detail: 'initial-prompt markers' };
+  }
+
+  if (isSubagentFromTranscript(transcriptPath, agentAliases)) {
+    return { decision: true, signal: SIGNALS.TASK_SCAN, detail: 'active Task dispatch' };
+  }
+
+  if (isAgentFromFrontmatter(transcriptPath, agentAliases)) {
+    return { decision: true, signal: SIGNALS.FRONTMATTER, detail: 'legacy frontmatter name' };
+  }
+
+  return { decision: false, signal: SIGNALS.NONE, detail: 'no identity signal matched' };
+}
+
+/**
+ * Debug/observability classifier: "am I agent X, and WHICH signal decided?"
+ *
+ * Same walk (and same verdicts) as `isRunningInAgent`, but returns
+ * `{ decision, signal }` where `signal` names the deciding step
+ * (payload | env | codex-rollout | structural-marker | task-scan |
+ * frontmatter | none). Emits exactly one `[agent-identity]` stderr line per
+ * call when `ENFORCE_HOOK_DEBUG` is set. Fail-open `{ decision: false,
+ * signal: 'none' }` on error.
+ */
+function classifyIdentity(transcriptPath, agentAliases, hookData) {
+  let result;
+  try {
+    result = classifySignal(transcriptPath, agentAliases || [], hookData);
+  } catch {
+    result = { decision: false, signal: SIGNALS.NONE, detail: 'classification error' };
+  }
+  debugLog(result.signal, result.detail);
+  return { decision: result.decision, signal: result.signal };
+}
+
+module.exports = {
+  // Re-exported legs (see contract header)
+  isRunningInAgent,
+  isDispatchedAgentContext,
+  isSubagentContext,
+  isSubagentFromInitialPrompt,
+  normalizeAgentName,
+  matchesAlias,
+  readInitialMarkers,
+  // New accessors (GH-767)
+  payloadAgentName,
+  dispatchTargetAgent,
+  envAgentName,
+  classifyIdentity,
+  activeAgentDetectionPayload,
+  // Signal-name constants (shared with the JSDoc precedence table)
+  SIGNALS,
+};

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/enforce-agent-usage.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/enforce-agent-usage.test.js
@@ -41,3 +41,28 @@ describe('enforce-agent-usage — Semantic Commits rule', () => {
     assert.ok(COMMIT_SCRIPT.endsWith(path.join('work', 'scripts', 'commit-and-push.js')));
   });
 });
+
+// GH-767 Task 3: the migrated primary hooks obtain identity from the
+// canonical agent-identity module — require-path assertions only (no
+// behavior assertions; the suites above are the behavior anchor).
+describe('enforce-agent-usage — GH-767 agent-identity migration (require paths)', () => {
+  const fs = require('fs');
+  const LIB = path.join(__dirname, '..', '..');
+  const MIGRATED = [
+    'hooks/agent-hook-dispatcher.js',
+    'hooks/enforce-agent-usage.js',
+    'hooks/enforce-step-workflow.js',
+    'hooks/enforce-screenshot-requirement.js',
+    'hooks/policies/agent-gate-rule.js',
+    'hooks/policies/step-gate.js',
+    'hooks/policies/workflow-loop-rules.js',
+  ];
+
+  it('every migrated hook requires agent-identity, never agent-detection', () => {
+    for (const rel of MIGRATED) {
+      const src = fs.readFileSync(path.join(LIB, rel), 'utf8');
+      assert.ok(src.includes('agent-identity'), `${rel} must require agent-identity`);
+      assert.ok(!src.includes("agent-detection'"), `${rel} must not require agent-detection`);
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
@@ -32,18 +32,13 @@ const { isRunningInAgent, activeAgentDetectionPayload } = require(
   path.join(__dirname, '..', 'agent-identity')
 );
 const { REGISTRY } = require(path.join(__dirname, 'agent-hook-registry'));
-const { resolvePluginRootHonouringEnv } = require('../../work/lib/resolve-plugin-root');
+const { installFailOpenHandlers, resolveHookPluginRoot } = require(
+  path.join(__dirname, 'hook-bootstrap')
+);
 
 const VALID_HOOK_TYPES = new Set(['PreToolUse', 'PostToolUse', 'Stop']);
 
-process.on('uncaughtException', (err) => {
-  logHookError(__filename, err);
-  process.exit(0);
-});
-process.on('unhandledRejection', (err) => {
-  logHookError(__filename, err);
-  process.exit(0);
-});
+installFailOpenHandlers(__filename);
 
 function readStdin() {
   return new Promise((resolve) => {
@@ -78,9 +73,7 @@ function resolvePluginRoot() {
   // we must trust the user's env setting when probing lands on an unrelated
   // install (which is exactly what happens in test fixtures and in the
   // marketplace-nesting case tracked by GH-526).
-  return (
-    resolvePluginRootHonouringEnv(__dirname, 4) || path.resolve(__dirname, '..', '..', '..', '..')
-  );
+  return resolveHookPluginRoot(__dirname, 4);
 }
 
 function runEntry(entry, stdinBuffer, pluginRoot) {
@@ -117,6 +110,48 @@ function runEntry(entry, stdinBuffer, pluginRoot) {
   return { code: result.status == null ? 0 : result.status };
 }
 
+function parseHookPayload(stdinBuffer) {
+  try {
+    return JSON.parse(stdinBuffer.toString('utf8') || '{}');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find which registered agent (if any) is currently active.
+ * activeAgentDetectionPayload() strips the dispatch-target field
+ * (tool_input.subagent_type) as a belt-and-suspenders defense against any
+ * non-Task tool that happens to carry it — only the Task tool's tool_input
+ * legitimately names a target agent, and main() short-circuits that before
+ * calling here. A dispatch target is NEVER self-identity.
+ */
+function findActiveAgent(hookData) {
+  const detectionHookData = activeAgentDetectionPayload(hookData);
+  const transcriptPath = hookData.transcript_path || '';
+  for (const agentName of Object.keys(REGISTRY)) {
+    if (isRunningInAgent(transcriptPath, [agentName], detectionHookData)) {
+      return agentName;
+    }
+  }
+  return null;
+}
+
+/**
+ * Run each matching entry in order; return the first blocking exit code
+ * (non-zero from a non-optional entry), or 0 when everything allows.
+ */
+function dispatchEntries(entries, hookData, hookType, stdinBuffer, pluginRoot) {
+  for (const entry of entries) {
+    if (!matcherAllows(entry, hookData, hookType)) continue;
+    const { code } = runEntry(entry, stdinBuffer, pluginRoot);
+    if (code !== 0 && !entry.optional) {
+      return code;
+    }
+  }
+  return 0;
+}
+
 async function main() {
   const hookType = process.env.CLAUDE_HOOK_TYPE;
   if (!VALID_HOOK_TYPES.has(hookType)) {
@@ -125,14 +160,8 @@ async function main() {
   }
 
   const stdinBuffer = await readStdin();
-  let hookData = {};
-  try {
-    hookData = JSON.parse(stdinBuffer.toString('utf8') || '{}');
-  } catch {
-    process.exit(0);
-  }
-
-  const pluginRoot = resolvePluginRoot();
+  const hookData = parseHookPayload(stdinBuffer);
+  if (!hookData) process.exit(0);
 
   // Guard: when the current tool is Task/Agent, the call is the PARENT
   // *about to invoke* a subagent — the subagent isn't running yet.
@@ -145,35 +174,13 @@ async function main() {
     process.exit(0);
   }
 
-  // Find which registered agent (if any) is currently active.
-  // activeAgentDetectionPayload() strips the dispatch-target field
-  // (tool_input.subagent_type) as a belt-and-suspenders defense against any
-  // non-Task tool that happens to carry it — only the Task tool's tool_input
-  // legitimately names a target agent, and we've already short-circuited
-  // that above. A dispatch target is NEVER self-identity.
-  const detectionHookData = activeAgentDetectionPayload(hookData);
-  const transcriptPath = hookData.transcript_path || '';
-  let activeAgent = null;
-  for (const agentName of Object.keys(REGISTRY)) {
-    if (isRunningInAgent(transcriptPath, [agentName], detectionHookData)) {
-      activeAgent = agentName;
-      break;
-    }
-  }
+  const activeAgent = findActiveAgent(hookData);
   if (!activeAgent) process.exit(0);
 
   const entries = REGISTRY[activeAgent][hookType];
   if (!entries || entries.length === 0) process.exit(0);
 
-  for (const entry of entries) {
-    if (!matcherAllows(entry, hookData, hookType)) continue;
-    const { code } = runEntry(entry, stdinBuffer, pluginRoot);
-    if (code !== 0 && !entry.optional) {
-      process.exit(code);
-    }
-  }
-
-  process.exit(0);
+  process.exit(dispatchEntries(entries, hookData, hookType, stdinBuffer, resolvePluginRoot()));
 }
 
 main();

--- a/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/agent-hook-dispatcher.js
@@ -28,7 +28,9 @@ const path = require('path');
 const { spawnSync } = require('child_process');
 
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
-const { isRunningInAgent } = require(path.join(__dirname, '..', 'agent-detection'));
+const { isRunningInAgent, activeAgentDetectionPayload } = require(
+  path.join(__dirname, '..', 'agent-identity')
+);
 const { REGISTRY } = require(path.join(__dirname, 'agent-hook-registry'));
 const { resolvePluginRootHonouringEnv } = require('../../work/lib/resolve-plugin-root');
 
@@ -144,14 +146,12 @@ async function main() {
   }
 
   // Find which registered agent (if any) is currently active.
-  // Pass a hookData copy with tool_input.subagent_type stripped as a
-  // belt-and-suspenders defense against any non-Task tool that happens
-  // to carry that field — only the Task tool's tool_input legitimately
-  // names a target agent, and we've already short-circuited that above.
-  const detectionHookData =
-    hookData.tool_input && hookData.tool_input.subagent_type
-      ? { ...hookData, tool_input: { ...hookData.tool_input, subagent_type: undefined } }
-      : hookData;
+  // activeAgentDetectionPayload() strips the dispatch-target field
+  // (tool_input.subagent_type) as a belt-and-suspenders defense against any
+  // non-Task tool that happens to carry it — only the Task tool's tool_input
+  // legitimately names a target agent, and we've already short-circuited
+  // that above. A dispatch target is NEVER self-identity.
+  const detectionHookData = activeAgentDetectionPayload(hookData);
   const transcriptPath = hookData.transcript_path || '';
   let activeAgent = null;
   for (const agentName of Object.keys(REGISTRY)) {

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-agent-usage.js
@@ -20,7 +20,12 @@
  */
 
 const path = require('path');
-const { isRunningInAgent } = require('../agent-detection');
+const {
+  isRunningInAgent,
+  envAgentName,
+  dispatchTargetAgent,
+  payloadAgentName,
+} = require('../agent-identity');
 const { commandAccessesProtectedPaths } = require('../command-analysis');
 const { runHook } = require('../hookEntrypoint');
 // Vendored dual-runtime adapter: runtime detection for the per-runtime block
@@ -156,17 +161,15 @@ function skillSelfCall(skillName, blocked, transcriptPath) {
 
 /** Task-tool self-call: dispatched subagent equals the currently-running agent. */
 function taskSelfCall(subagentType, blocked) {
-  const currentAgent = process.env.CLAUDE_CURRENT_AGENT;
+  const currentAgent = envAgentName();
   return (
-    subagentType === blocked &&
-    Boolean(currentAgent) &&
-    currentAgent.toLowerCase() === blocked.toLowerCase()
+    subagentType === blocked && Boolean(currentAgent) && currentAgent === blocked.toLowerCase()
   );
 }
 
 function blockSelfCall(toolName, toolInput, transcriptPath) {
   const skillName = toolInput?.skill || '';
-  const subagentType = toolInput?.subagent_type || '';
+  const subagentType = dispatchTargetAgent(toolInput);
   for (const blocked of SELF_CALL_BLOCKED_AGENTS) {
     if (toolName === 'Skill' && skillSelfCall(skillName, blocked, transcriptPath)) {
       process.stderr.write(
@@ -186,8 +189,7 @@ function blockSelfCall(toolName, toolInput, transcriptPath) {
 
 function agentHintsMatch(hookData, transcriptPath, agentAliases) {
   const hints = [
-    hookData.agent_name,
-    hookData.agent_type,
+    payloadAgentName(hookData),
     process.env.CLAUDE_AGENT_TYPE,
     transcriptPath ? require('path').basename(transcriptPath) : '',
   ]

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
@@ -165,46 +165,59 @@ function hasScreenshots(ticketId) {
   }
 }
 
-function blockIfNoScreenshots(hookData) {
-  const ticketId = getTicketId();
-  if (!ticketId) return;
-  // Skip screenshot enforcement when no web apps are configured (GH-181).
-  // Resolve WEB_APPS through lib/config (dotenv-aware): a raw process.env
-  // read misses values that live only in the repo/cwd .env file (PR #628
-  // finding — same fix as check validate-summary/verify-playwright). The
-  // old "circular dependency" concern was stale: this hook already requires
-  // ../config in getScreenshotDir. Fail-open on config load errors so a
-  // misconfigured environment never bricks the hook.
-  let hasConfiguredWebApps = false;
+/**
+ * Skip screenshot enforcement when no web apps are configured (GH-181).
+ * Resolve WEB_APPS through lib/config (dotenv-aware): a raw process.env
+ * read misses values that live only in the repo/cwd .env file (PR #628
+ * finding — same fix as check validate-summary/verify-playwright). The
+ * old "circular dependency" concern was stale: this hook already requires
+ * ../config in getScreenshotDir. Fail-open on config load errors so a
+ * misconfigured environment never bricks the hook.
+ */
+function hasConfiguredWebApps() {
   try {
-    hasConfiguredWebApps = require('../config').webAppNames().length > 0;
+    return require('../config').webAppNames().length > 0;
   } catch {
     process.stderr.write(
       'warn: screenshot-requirement: could not resolve WEB_APPS config, treating as empty\n'
     );
+    return false;
   }
-  if (!hasConfiguredWebApps) return;
-  if (fs.existsSync(skipMarkerPath(ticketId))) return;
-  if (!hasTsxChanges()) return;
-  if (hasScreenshots(ticketId)) return;
+}
 
-  const toolName = hookData.tool_name || '';
+/** True when the situation calls for enforcement at all (TSX changed, no screenshots, no skip). */
+function screenshotsMissing(ticketId) {
+  if (!hasConfiguredWebApps()) return false;
+  if (fs.existsSync(skipMarkerPath(ticketId))) return false;
+  if (!hasTsxChanges()) return false;
+  if (hasScreenshots(ticketId)) return false;
+  return true;
+}
+
+const QA_TARGET_AGENTS = new Set(['qa-feature-tester', 'pr-generator', 'pr-post-generator']);
+
+/** Task dispatch targeting a QA-completing agent (or a QA-flavored prompt). */
+function isQaAgentDispatch(hookData) {
+  if (hookData.tool_name !== 'Task') return false;
   const prompt = (hookData.tool_input?.prompt || '').toLowerCase();
-  const skill = (hookData.tool_input?.skill || '').toLowerCase();
   // dispatchTargetAgent() normalizes (strips plugin prefixes like
   // "work-workflow:" and lowercases) — a dispatch target, never self-identity.
   const normalizedSubagentType = dispatchTargetAgent(hookData.tool_input);
+  return QA_TARGET_AGENTS.has(normalizedSubagentType) || /screenshot|qa.*report/i.test(prompt);
+}
 
-  const isQaAgent =
-    toolName === 'Task' &&
-    (normalizedSubagentType === 'qa-feature-tester' ||
-      normalizedSubagentType === 'pr-generator' ||
-      normalizedSubagentType === 'pr-post-generator' ||
-      /screenshot|qa.*report/i.test(prompt));
+/** Skill invocation that completes QA or opens a PR. */
+function isCompletingSkillCall(hookData) {
+  if (hookData.tool_name !== 'Skill') return false;
+  const skill = (hookData.tool_input?.skill || '').toLowerCase();
+  return /work-pr|check-qa|check-browser/i.test(skill);
+}
 
-  const isCompletingSkill = toolName === 'Skill' && /work-pr|check-qa|check-browser/i.test(skill);
-
-  if (!isQaAgent && !isCompletingSkill) return;
+function blockIfNoScreenshots(hookData) {
+  const ticketId = getTicketId();
+  if (!ticketId) return;
+  if (!screenshotsMissing(ticketId)) return;
+  if (!isQaAgentDispatch(hookData) && !isCompletingSkillCall(hookData)) return;
 
   const screenshotDir = getScreenshotDir(ticketId);
   process.stderr.write(

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-screenshot-requirement.js
@@ -15,6 +15,7 @@ const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
+const { dispatchTargetAgent } = require(path.join(__dirname, '..', 'agent-identity'));
 
 const MARKER_DIR = '/tmp';
 const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
@@ -190,8 +191,9 @@ function blockIfNoScreenshots(hookData) {
   const toolName = hookData.tool_name || '';
   const prompt = (hookData.tool_input?.prompt || '').toLowerCase();
   const skill = (hookData.tool_input?.skill || '').toLowerCase();
-  const subagentType = hookData.tool_input?.subagent_type || '';
-  const normalizedSubagentType = subagentType.replace(/^work-workflow:/, '');
+  // dispatchTargetAgent() normalizes (strips plugin prefixes like
+  // "work-workflow:" and lowercases) — a dispatch target, never self-identity.
+  const normalizedSubagentType = dispatchTargetAgent(hookData.tool_input);
 
   const isQaAgent =
     toolName === 'Task' &&

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-step-workflow.js
@@ -46,9 +46,9 @@ process.on('unhandledRejection', (err) => {
   process.exit(didBlock ? 2 : 0);
 });
 
-// Agent detection for report file protection + GH-695 dispatched-agent gate
+// Agent identity for report file protection + GH-695 dispatched-agent gate
 const { isRunningInAgent, isDispatchedAgentContext, normalizeAgentName } = require(
-  path.join(__dirname, '..', 'agent-detection')
+  path.join(__dirname, '..', 'agent-identity')
 );
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
 

--- a/plugins/work/scripts/workflows/lib/hooks/policies/agent-gate-rule.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/agent-gate-rule.js
@@ -20,6 +20,7 @@ const path = require('path');
 
 const { getNodeInvocations } = require('./command-matching');
 const { isTrustedScriptPath, expandPluginRoot } = require('./agent-authorization');
+const { envAgentName, dispatchTargetAgent, payloadAgentName } = require('../../agent-identity');
 const { logHookError } = require('../../hook-error-log');
 const { tokenPath, ensureTokenDir } = require('../../scripts/write-report');
 
@@ -96,10 +97,10 @@ function checkStepGate(deps, scriptBase, gatedEntry, ticketId) {
 // Agent + step verified — pick the agent identity to stamp into the token.
 function detectAgent(deps, allowedAgents, hookData) {
   const norm = deps.normalizeAgentName;
-  const envAgent = process.env.CLAUDE_CURRENT_AGENT;
-  if (envAgent && allowedAgents.some((a) => norm(a) === norm(envAgent))) return envAgent;
-  const hd = hookData?.tool_input?.subagent_type;
-  if (hd && allowedAgents.some((a) => norm(a) === norm(hd))) return hd;
+  const envAgent = envAgentName();
+  if (envAgent && allowedAgents.some((a) => norm(a) === envAgent)) return envAgent;
+  const hd = dispatchTargetAgent(hookData?.tool_input);
+  if (hd && allowedAgents.some((a) => norm(a) === hd)) return hd;
   return allowedAgents[0];
 }
 
@@ -194,9 +195,9 @@ function logRule5Match(tokenLog, scriptBase, scriptPath, ticketId, cmd, hookData
     scriptPath,
     ticketId: ticketId || null,
     cmd: cmd.slice(0, 300),
-    envAgent: process.env.CLAUDE_CURRENT_AGENT || null,
-    subagentType: hookData?.tool_input?.subagent_type || null,
-    hookAgentType: hookData?.agent_type || null,
+    envAgent: envAgentName() || null,
+    subagentType: dispatchTargetAgent(hookData?.tool_input) || null,
+    hookAgentType: payloadAgentName(hookData) || null,
   });
 }
 

--- a/plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
@@ -12,6 +12,8 @@
  *   - getCurrentStep(state, steps): find the in_progress step from a state object
  */
 
+const { dispatchTargetAgent } = require('../../agent-identity');
+
 /**
  * Find the in_progress step from a workflow state object.
  * Returns the first one if multiple are in_progress (legacy data tolerance).
@@ -48,7 +50,7 @@ function evaluateStepGate({
   // /check agent bypass: when running an agent owned by /check during /work,
   // allow it if /check is currently active.
   if (workflowName === 'work') {
-    const agentType = toolInput?.subagent_type || '';
+    const agentType = dispatchTargetAgent(toolInput);
     if (agentType && checkAgents.has(agentType) && checkStateActive) {
       return { blocked: false };
     }

--- a/plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/step-gate.js
@@ -24,6 +24,12 @@ function getCurrentStep(state, steps) {
   return active[0] || null;
 }
 
+/** Human-readable description of the tool call, for block messages. */
+function describeToolCall(toolInput) {
+  const cmdDesc = toolInput?.command || toolInput?.skill || toolInput?.subagent_type || '(unknown)';
+  return String(cmdDesc);
+}
+
 /**
  * @param {object} args
  * @param {string} args.workflowName
@@ -56,8 +62,7 @@ function evaluateStepGate({
     }
   }
 
-  const cmdDesc = toolInput?.command || toolInput?.skill || toolInput?.subagent_type || '(unknown)';
-  return { blocked: true, matchedStep, currentStep, cmdDesc: String(cmdDesc) };
+  return { blocked: true, matchedStep, currentStep, cmdDesc: describeToolCall(toolInput) };
 }
 
 /**

--- a/plugins/work/scripts/workflows/lib/hooks/policies/workflow-loop-rules.js
+++ b/plugins/work/scripts/workflows/lib/hooks/policies/workflow-loop-rules.js
@@ -16,6 +16,7 @@
  * — stays in the hook entry's loops, so both callers guard before invoking these.
  */
 
+const { dispatchTargetAgent } = require('../../agent-identity');
 const { matchToolToStep, isExempt } = require('./command-matching');
 const { evaluateTransitionGate, formatTransitionBlockMessage } = require('./transition-gate');
 const { evaluateStepGate, formatStepBlockMessage } = require('./step-gate');
@@ -107,7 +108,7 @@ function checkTransitionPre(deps, wf, currentStep, transition, ctx) {
 // name kept as a fallback for in-flight tickets that predate the rename)
 function computeCheckStateActive(deps, wf, matchedStep, currentStep, ctx) {
   if (wf.name !== 'work' || matchedStep === currentStep) return false;
-  const agentType = ctx.toolInput?.subagent_type || '';
+  const agentType = dispatchTargetAgent(ctx.toolInput);
   if (!deps.checkAgents.has(agentType)) return false;
   const checkState =
     deps.loadStateFile(ctx.ticketId, '.check-state.json') ||

--- a/plugins/work/scripts/workflows/lib/transcript-markers.js
+++ b/plugins/work/scripts/workflows/lib/transcript-markers.js
@@ -12,6 +12,10 @@
  *
  * agent-detection.js requires and re-exports these, so consumers keep their
  * existing import path.
+ *
+ * Required by: lib/agent-identity.js (the canonical GH-767 entry point —
+ * new consumers import that module, not this internal leg) and
+ * lib/agent-detection.js (the claude scanning leg).
  */
 
 const fs = require('fs');

--- a/plugins/work/scripts/workflows/work-implement/__tests__/enforce-tdd-on-stop-codex-transcript.test.js
+++ b/plugins/work/scripts/workflows/work-implement/__tests__/enforce-tdd-on-stop-codex-transcript.test.js
@@ -86,3 +86,33 @@ describe('transcriptIsDeveloperDispatch — codex rollout leg', () => {
     assert.equal(transcriptIsDeveloperDispatch(file), true);
   });
 });
+
+// GH-767 Task 5 — require-path assertions ONLY (no behavior assertions):
+// the five migrated consumers must obtain identity through the canonical
+// lib/agent-identity.js module instead of inline payload triple-reads.
+describe('GH-767 consumer migration — agent-identity require paths', () => {
+  const WORKFLOWS_ROOT = path.resolve(__dirname, '..', '..');
+  const MIGRATED_FILES = [
+    'work-implement/hooks/enforce-developer-detect.js',
+    'work-implement/hooks/enforce-tdd-on-stop.js',
+    'work-implement/hooks/enforce-tdd-on-stop-helpers.js',
+    'work/agents/developer-quality-gate.js',
+    'work-pr/agents/lib/hook-io.js',
+  ];
+
+  for (const rel of MIGRATED_FILES) {
+    it(`${rel} reads identity via the module boundary`, () => {
+      const source = fs.readFileSync(path.join(WORKFLOWS_ROOT, rel), 'utf8');
+      // The helpers file has no payload read — its swap is the dual-format
+      // transcript reader; every other file requires agent-identity directly.
+      const boundaryRe = rel.endsWith('enforce-tdd-on-stop-helpers.js')
+        ? /require\([^)]*runtime[^)]*transcript[^)]*\)/
+        : /require\([^)]*agent-identity[^)]*\)/;
+      assert.match(source, boundaryRe);
+      // The divergent inline triple-read is deleted (no raw payload-field
+      // fallback chains outside the module).
+      assert.doesNotMatch(source, /\.agent_type\s*\|\|/);
+      assert.doesNotMatch(source, /\.agent_name\s*\|\|/);
+    });
+  }
+});

--- a/plugins/work/scripts/workflows/work-implement/hooks/enforce-developer-detect.js
+++ b/plugins/work/scripts/workflows/work-implement/hooks/enforce-developer-detect.js
@@ -15,6 +15,9 @@ const path = require('path');
 const { sniffFormat, readToolEvents } = require(
   path.join(__dirname, '..', '..', 'lib', 'runtime', 'transcript')
 );
+const { payloadAgentName, matchesAlias } = require(
+  path.join(__dirname, '..', '..', 'lib', 'agent-identity')
+);
 
 // Developer agents that satisfy the requirement
 const DEVELOPER_AGENTS = [
@@ -27,16 +30,17 @@ const DEVELOPER_AGENTS = [
 
 /**
  * Payload-first developer identification (design C12): when the hook fires
- * inside a subagent, the payload's `agent_type` names it on both runtimes —
- * codex sets no CLAUDE_* env vars and its rollout transcript is unreadable
- * by the claude scan below.
+ * inside a subagent, the payload's self-identity field names it on both
+ * runtimes — codex sets no CLAUDE_* env vars and its rollout transcript is
+ * unreadable by the claude scan below.
+ *
+ * Identity is read via the canonical `lib/agent-identity.js` accessors
+ * (GH-767); the DEVELOPER_AGENTS list itself stays local — WHICH agents are
+ * developers is this hook's policy, not an identity primitive.
  */
 function payloadIsDeveloperAgent(hookData) {
-  const agentType = String(hookData?.agent_type || '')
-    .replace(/^[\w-]+:/, '')
-    .toLowerCase();
-  if (!agentType) return false;
-  return DEVELOPER_AGENTS.some((agent) => agent.toLowerCase() === agentType);
+  const agentType = payloadAgentName(hookData);
+  return Boolean(agentType) && matchesAlias(agentType, DEVELOPER_AGENTS);
 }
 
 /** Matches an inline persona adoption: a shell read of agents/developer-*.md. */

--- a/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop-helpers.js
+++ b/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop-helpers.js
@@ -88,44 +88,30 @@ function resolveWorktreeDir(workState, safeTicket) {
  * @param {string|undefined} transcriptPath
  * @returns {boolean}
  */
-function _messageText(entry) {
-  const content = entry.message && entry.message.content;
-  if (typeof content === 'string') return content;
-  if (!Array.isArray(content)) return '';
-  return content.map((i) => (i && i.text) || '').join(' ');
-}
-
 /** Text of the transcript's FIRST user message, or null when unreadable. */
 function _firstUserMessageText(transcriptPath) {
   if (!transcriptPath || !fs.existsSync(transcriptPath)) return null;
 
-  // Codex rollout transcripts (SubagentStop agent_transcript_path on codex):
-  // the claude line scan below can't read them — take the FIRST authored user
-  // message via the vendored dual-format reader (event_msg/user_message
-  // records only; injected context is never mistaken for the dispatch
-  // prompt). Payload `agent_type` remains the primary identification — this
-  // fallback only runs on payloads without it (see enforce-tdd-on-stop.js).
-  const { sniffFormat, readUserMessages } = require(
+  // GH-767 import swap: BOTH transcript formats are read via the vendored
+  // dual-format reader (module boundary — never raw-read the transcript
+  // here). On codex rollouts only event_msg/user_message records count
+  // (injected context is never mistaken for the dispatch prompt); on claude
+  // project JSONL only `user` records' string/text-block content counts.
+  // Payload identity remains the primary identification — this fallback only
+  // runs on payloads without it (see enforce-tdd-on-stop.js).
+  const { readUserMessages } = require(
     path.join(__dirname, '..', '..', 'lib', 'runtime', 'transcript')
   );
-  if (sniffFormat(transcriptPath) === 'codex') {
-    const messages = readUserMessages(transcriptPath, { count: Number.MAX_SAFE_INTEGER });
-    return messages.length > 0 ? messages[0] : null;
-  }
-
-  for (const line of fs.readFileSync(transcriptPath, 'utf8').split('\n')) {
-    if (!line.trim()) continue;
-    let entry;
-    try {
-      entry = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    if (entry && entry.type === 'user') return _messageText(entry);
-  }
-  return null;
+  const messages = readUserMessages(transcriptPath, { count: Number.MAX_SAFE_INTEGER });
+  return messages.length > 0 ? messages[0] : null;
 }
 
+// NOTE (GH-767): the 'self-paced TDD agent' + task-next.js dispatch-prompt
+// marker is developer-gating POLICY local to this hook — it is NOT an
+// identity-detection primitive and deliberately does not live in
+// lib/agent-identity.js. Identity questions (payload/env/transcript agent
+// identity) go through that module; this predicate only recognizes the
+// implement step's own dispatch prompt.
 function transcriptIsDeveloperDispatch(transcriptPath) {
   try {
     const text = _firstUserMessageText(transcriptPath);

--- a/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop.js
+++ b/plugins/work/scripts/workflows/work-implement/hooks/enforce-tdd-on-stop.js
@@ -85,11 +85,15 @@ const {
   citationBlockMessage,
 } = require(path.join(__dirname, 'enforce-tdd-on-stop-helpers'));
 
+// Canonical agent-identity module (GH-767) — the ONE payload self-identity
+// accessor (`agent_type || agent_name || subagent_type`, normalized).
+const { payloadAgentName } = require(path.join(__dirname, '..', '..', 'lib', 'agent-identity'));
+
 // ─── Self-filter: only POSITIVELY-identified developer-* agents are gated ──
 // SubagentStop fires for every subagent (commit-writer, pr-generator, qa-*…).
-// Claude Code's documented SubagentStop payload identifies the agent via
-// `agent_type` ("present only when the hook fires inside a subagent call");
-// legacy `agent_name` / `subagent_type` are read as fallbacks. When no
+// Self-identity is read via the canonical module's `payloadAgentName()`
+// (payload `agent_type` first — the documented SubagentStop field — with the
+// legacy `agent_name` / `subagent_type` fallbacks, normalized). When no
 // payload field is present (older builds), fall back to the subagent
 // transcript's first user message: the developer dispatch prompt
 // (step-enrichments/implement.js) carries the structural 'self-paced TDD
@@ -97,9 +101,7 @@ const {
 // must never gate arbitrary subagents — the previous negative filter fell
 // through to the evidence check for EVERY payload without an agent name,
 // exit-2-blocking code-checker/Explore/commit-writer mid-task.
-const _agentName = String(
-  _hookData.agent_type || _hookData.agent_name || _hookData.subagent_type || ''
-).toLowerCase();
+const _agentName = payloadAgentName(_hookData);
 const _isDeveloperAgent = _agentName
   ? /(^|:)developer-/.test(_agentName)
   : transcriptIsDeveloperDispatch(_hookData.transcript_path);

--- a/plugins/work/scripts/workflows/work-pr/agents/lib/hook-io.js
+++ b/plugins/work/scripts/workflows/work-pr/agents/lib/hook-io.js
@@ -7,6 +7,11 @@
 
 'use strict';
 
+const path = require('path');
+const { payloadAgentName } = require(
+  path.join(__dirname, '..', '..', '..', 'lib', 'agent-identity')
+);
+
 // Read all of stdin to a string.
 async function readStdin() {
   let input = '';
@@ -28,9 +33,10 @@ async function readHookDataStrict(label) {
   }
 }
 
-// Resolve the subagent name from the hook payload (lowercased for matching).
+// Resolve the subagent name from the hook payload (normalized for matching)
+// via the canonical agent-identity accessor (GH-767).
 function resolveAgentName(hookData) {
-  return (hookData.agent_name || hookData.subagent_type || '').toLowerCase();
+  return payloadAgentName(hookData);
 }
 
 // Resolve the agent's textual output across the payload field variants.

--- a/plugins/work/scripts/workflows/work/agents/developer-quality-gate.js
+++ b/plugins/work/scripts/workflows/work/agents/developer-quality-gate.js
@@ -20,6 +20,7 @@ const path = require('path');
 const { runQualityCheck, describeStrategy } = require(
   path.join(__dirname, '..', '..', 'lib', 'quality-check')
 );
+const { payloadAgentName } = require(path.join(__dirname, '..', '..', 'lib', 'agent-identity'));
 
 /**
  * Check if there are actual code changes to validate.
@@ -56,15 +57,10 @@ async function main() {
     process.exit(2);
   }
 
-  // Check if this is a developer agent — payload agent_type first (the
-  // documented SubagentStop field on both runtimes; codex sets no legacy
-  // agent_name), then the legacy fields.
-  const agentName = (
-    hookData.agent_type ||
-    hookData.agent_name ||
-    hookData.subagent_type ||
-    ''
-  ).toLowerCase();
+  // Check if this is a developer agent — self-identity via the canonical
+  // module's payloadAgentName() (payload agent_type first, the documented
+  // SubagentStop field on both runtimes; legacy fields as fallbacks).
+  const agentName = payloadAgentName(hookData);
 
   // Skip if no code changes to validate
   if (!hasCodeChanges()) {


### PR DESCRIPTION
## Existing Behavior

- Agent identity is probed inconsistently across hooks: each hook reads env vars, payload fields, and transcript markers independently with no shared contract.
- agent-detection.js is the de-facto entry point but carries no documented API surface, making it easy for callers to bypass it and reach raw env/payload reads directly.
- The three distinct identity predicates have different fail directions but nothing enforces that callers use the right one for each question.
- No regression fixture exists for the GH-665 bricked-session class (main-session prompt that names an agent must not classify as that agent).

## Intended New Behavior

- lib/agent-identity.js is the single documented identity contract for all hooks; it centralizes six named identity questions with JSDoc specifying the fail direction of each.
- agent-detection.js becomes a thin re-export shim; a grep-guard test rejects any new inline reads of raw env/payload identity fields outside the canonical module.
- Primary lib hooks (dispatcher, enforce-agent-usage, enforce-step-workflow, agent-gate-rule, step-gate, workflow-loop-rules, enforce-screenshot-requirement) and work-step consumers (enforce-developer-detect, enforce-tdd-on-stop, developer-quality-gate, hook-io) all import from agent-identity.
- A permanent GH-665 regression fixture and a self-scanning grep-guard suite with a 15-entry shrink-only allowlist are added; the refactor commit removes three files from the .quality-exceptions ratchet.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Backend / hook verification:**

1. Confirm the canonical module resolves correctly:

```bash
node -e "const id = require('./plugins/work/scripts/workflows/lib/agent-identity'); console.log(Object.keys(id))"
```

Expected: array includes isRunningInAgent, isDispatchedAgentContext, isSubagentContext, payloadAgentName, dispatchTargetAgent, envAgentName, classifyIdentity.

2. Confirm agent-detection.js re-exports the same surface (shim check):

```bash
node -e "const a = require('./plugins/work/scripts/workflows/lib/agent-detection'); const b = require('./plugins/work/scripts/workflows/lib/agent-identity'); console.log(Object.keys(a).every(k => typeof b[k] === typeof a[k]))"
```

Expected: true.

3. Run the grep-guard and regression suites (CI will confirm):

```bash
node --test --test-concurrency=1 plugins/work/scripts/workflows/lib/__tests__/agent-identity-grep-guard.test.js
```

Expected: all tests pass; allowlist entry count must not exceed 15.

4. Confirm the quality ratchet shrunk (three fewer exceptions):

```bash
grep -c "." .quality-exceptions
```

Expected: enforce-screenshot-requirement.js, agent-hook-dispatcher.js, and step-gate.js are no longer listed.
### Test Results

| Test | Status | Notes |
|------|--------|-------|
| Unit tests (23 impacted test files) | PASS | Exit 0 — runs/run1/tests.check.md |
| Integration tests | PASS | Exit 0 — runs/run1/tests.check.md |
| E2E tests | PASS | Exit 0 — runs/run1/tests.check.md |
| Code review: Task-Doc Compliance (R1–R15) | PASS | All 15 spec requirements verified — code-review.check.md |
| Code review: TDD / Test Discipline | PASS | 40 test cases across 3 new suites — code-review.check.md |
| Code review: Code Smells / SOLID / Dependency Hygiene | PASS | No issues found — code-review.check.md |
| agent-identity-matrix.test.js (6 sources × 3 decisions) | PASS | runs/run1/tests.check.md |
| agent-identity-665-regression.test.js | PASS | runs/run1/tests.check.md |
| agent-identity-grep-guard.test.js | PASS | runs/run1/tests.check.md |

No screenshots — backend/hooks-only change (no UI components modified).

Closes #767