### PR TITLE
fix(test): honor file args and cap local concurrency in runners (GH-776)

### DIFF
--- a/plugins/work/scripts/__tests__/run-tests-args.test.js
+++ b/plugins/work/scripts/__tests__/run-tests-args.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/**
+ * run-tests.sh contract tests (GH-776): positional args become the file list
+ * (previously ignored — a single-file request ran the full suite), the local
+ * concurrency default is 1 with WORK_TEST_CONCURRENCY as the explicit
+ * override, and .test-skip filtering still applies to explicit args.
+ *
+ * Uses the script's WORK_TEST_LIST_ONLY=1 mode: prints the resolved file list
+ * plus `concurrency=<n>` and exits without running anything, so the contract
+ * is assertable without spawning the real suite.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SCRIPT = path.join(__dirname, '..', 'run-tests.sh');
+
+function runListOnly({ args = [], env = {}, cwd }) {
+  const out = execFileSync('bash', [SCRIPT, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: {
+      ...process.env,
+      WORK_TEST_LIST_ONLY: '1',
+      CI: '',
+      WORK_TEST_CONCURRENCY: '',
+      ...env,
+    },
+  });
+  const lines = out.trim().split('\n');
+  const concurrencyLine = lines.pop();
+  return { files: lines, concurrencyLine };
+}
+
+/** A tiny repo dir with two discoverable test files under plugins/. */
+function makeFixtureRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-tests-args-'));
+  fs.mkdirSync(path.join(dir, 'plugins', 'demo', '__tests__'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'plugins', 'demo', '__tests__', 'a.test.js'), '');
+  fs.writeFileSync(path.join(dir, 'plugins', 'demo', '__tests__', 'b.test.js'), '');
+  return dir;
+}
+
+describe('run-tests.sh argument and concurrency contract (GH-776)', () => {
+  it('positional args become the file list verbatim', () => {
+    const dir = makeFixtureRepo();
+    try {
+      const { files } = runListOnly({ args: ['x/one.test.js', 'y/two.test.js'], cwd: dir });
+      assert.deepEqual(files, ['x/one.test.js', 'y/two.test.js']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('no args discovers test files under plugins/', () => {
+    const dir = makeFixtureRepo();
+    try {
+      const { files } = runListOnly({ cwd: dir });
+      assert.deepEqual(files, [
+        'plugins/demo/__tests__/a.test.js',
+        'plugins/demo/__tests__/b.test.js',
+      ]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('.test-skip filtering applies to explicit args too', () => {
+    const dir = makeFixtureRepo();
+    try {
+      fs.writeFileSync(path.join(dir, '.test-skip'), 'one.test.js\n');
+      const { files } = runListOnly({ args: ['x/one.test.js', 'y/two.test.js'], cwd: dir });
+      assert.deepEqual(files, ['y/two.test.js']);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('local concurrency defaults to 1', () => {
+    const dir = makeFixtureRepo();
+    try {
+      const { concurrencyLine } = runListOnly({ cwd: dir });
+      assert.equal(concurrencyLine, 'concurrency=1');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('WORK_TEST_CONCURRENCY overrides the local default', () => {
+    const dir = makeFixtureRepo();
+    try {
+      const { concurrencyLine } = runListOnly({ cwd: dir, env: { WORK_TEST_CONCURRENCY: '4' } });
+      assert.equal(concurrencyLine, 'concurrency=4');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('CI=true pins concurrency to 1 regardless of the override', () => {
+    const dir = makeFixtureRepo();
+    try {
+      const { concurrencyLine } = runListOnly({
+        cwd: dir,
+        env: { CI: 'true', WORK_TEST_CONCURRENCY: '8' },
+      });
+      assert.equal(concurrencyLine, 'concurrency=1');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/work/scripts/__tests__/run-tests-args.test.js
+++ b/plugins/work/scripts/__tests__/run-tests-args.test.js
@@ -32,9 +32,14 @@ function runListOnly({ args = [], env = {}, cwd }) {
       ...env,
     },
   });
-  const lines = out.trim().split('\n');
-  const concurrencyLine = lines.pop();
-  return { files: lines, concurrencyLine };
+  // Locate the `concurrency=<n>` line explicitly rather than assuming it is
+  // the last line: on the empty-file path the script prints "No test files
+  // found" and exits BEFORE the list-only block, so a blind pop would hand
+  // back that message as the concurrency value. Assert loudly instead.
+  const lines = out.trim().split('\n').filter(Boolean);
+  const idx = lines.findIndex((l) => l.startsWith('concurrency='));
+  assert.notEqual(idx, -1, `list-only output missing a concurrency= line:\n${out}`);
+  return { files: lines.slice(0, idx), concurrencyLine: lines[idx] };
 }
 
 /** A tiny repo dir with two discoverable test files under plugins/. */

--- a/plugins/work/scripts/run-tests.sh
+++ b/plugins/work/scripts/run-tests.sh
@@ -39,21 +39,30 @@ trap cleanup_test_artifacts EXIT
 trap 'on_signal INT' INT
 trap 'on_signal TERM' TERM
 
-# Build space-separated file list (node --test expects positional args, not newlines)
-# Discover tests under any plugin (recursive), pruning node_modules. We also
-# prune plugins/work/hooks/__tests__: those orchestrator/session-state tests are
-# intentionally excluded from the suite (they share /tmp session-lock + workflow
-# state and flake when run concurrently with the other stateful work tests).
-# Discover under plugins/ AND factories/. Factories live at repo root (they're
-# stand-alone declarative builders shared across plugins), so they need to be
-# picked up explicitly — the prior `find plugins …` scope skipped them.
-mapfile -t FILES < <(
-  {
-    find plugins -type d \( -name node_modules -o -path 'plugins/work/hooks' \) -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
-    [ -d factories ] && find factories -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
-    [ -d scripts ] && find scripts -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
-  } | sort
-)
+# File list (node --test expects positional args, not newlines).
+# (GH-776) Positional arguments are the file list when given: `pnpm test
+# <file...>` runs exactly those files. Previously args were silently ignored
+# and every invocation ran the full suite — a single-file request from an
+# orchestrated agent fanned out to ~500 process-isolated test files.
+# With no args: discover tests under any plugin (recursive), pruning
+# node_modules. We also prune plugins/work/hooks/__tests__: those
+# orchestrator/session-state tests are intentionally excluded from the suite
+# (they share /tmp session-lock + workflow state and flake when run
+# concurrently with the other stateful work tests). Discover under plugins/
+# AND factories/. Factories live at repo root (they're stand-alone declarative
+# builders shared across plugins), so they need to be picked up explicitly —
+# the prior `find plugins …` scope skipped them.
+if [ "$#" -gt 0 ]; then
+  FILES=("$@")
+else
+  mapfile -t FILES < <(
+    {
+      find plugins -type d \( -name node_modules -o -path 'plugins/work/hooks' \) -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
+      [ -d factories ] && find factories -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
+      [ -d scripts ] && find scripts -type d -name node_modules -prune -o -type f \( -name '*.test.js' -o -name '*.spec.js' \) -print
+    } | sort
+  )
+fi
 
 if [ -f "$SKIP_FILE" ]; then
   FILTERED=()
@@ -73,18 +82,32 @@ if [ ${#FILES[@]} -eq 0 ]; then
   exit 0
 fi
 
+# (GH-452) --test-concurrency=1 serializes test files on CI: the
+# enforce-step-workflow suite spawns many hook subprocesses that share
+# TASKS_BASE for state I/O and intermittently lose write/read coherence
+# under contention (the file-not-found races chased on GH-452).
+# (GH-776) The LOCAL default is also 1: `node --test` with process isolation
+# defaults to CPU-count concurrency, and on a box running several concurrent
+# agent sessions a full-suite run took every core (observed load 39 on 14
+# cores). Override explicitly with WORK_TEST_CONCURRENCY=<n> when parallel
+# files are genuinely wanted.
+if [ "${CI:-}" = "true" ]; then
+  CONCURRENCY=1
+else
+  CONCURRENCY="${WORK_TEST_CONCURRENCY:-1}"
+fi
+
+# (GH-776) List-only mode: print the resolved file list + concurrency and exit
+# without running anything. Lets tests assert the arg/skip/concurrency
+# contract cheaply (spawning the real suite to test the runner is unusable).
+if [ "${WORK_TEST_LIST_ONLY:-}" = "1" ]; then
+  printf '%s\n' "${FILES[@]}"
+  echo "concurrency=$CONCURRENCY"
+  exit 0
+fi
+
 # Pre-clean (in case a prior run died before its trap could fire)
 cleanup_test_artifacts
 
 # Run tests; trap will fire cleanup on exit (clean or interrupted)
-# (GH-452) Force --test-concurrency=1 on CI to serialize test files. The
-# enforce-step-workflow suite spawns many hook subprocesses that share
-# TASKS_BASE for state I/O; parallel runs on the 2-CPU GitHub Actions
-# ubuntu-latest runner contend for fs cache and intermittently lose
-# state-file write/read coherence (the file-not-found races chased on
-# GH-452). Locally we keep the default (CPU count) so devs aren't penalized.
-if [ "${CI:-}" = "true" ]; then
-  node --test --test-concurrency=1 "${FILES[@]}"
-else
-  node --test "${FILES[@]}"
-fi
+node --test --test-concurrency="$CONCURRENCY" "${FILES[@]}"

--- a/plugins/work/scripts/workflows/lib/scripts/dev-check/dev-test.sh
+++ b/plugins/work/scripts/workflows/lib/scripts/dev-check/dev-test.sh
@@ -97,7 +97,16 @@ run_tests() {
       # (GH-776) Default to one test process — node --test's CPU-count default
       # with process isolation takes every core on a box running several
       # concurrent agent sessions. Override via WORK_TEST_CONCURRENCY=<n>.
-      (cd "$dir" && echo "$abs_test_files" | tr '\n' '\0' | xargs -0 node --test --test-concurrency="${WORK_TEST_CONCURRENCY:-1}" --) || {
+      # CI is pinned to 1 regardless of the override, matching run-tests.sh:
+      # concurrent hook subprocesses contend over TASKS_BASE state I/O and lose
+      # write/read coherence under parallelism (GH-452).
+      local concurrency
+      if [ "${CI:-}" = "true" ]; then
+        concurrency=1
+      else
+        concurrency="${WORK_TEST_CONCURRENCY:-1}"
+      fi
+      (cd "$dir" && echo "$abs_test_files" | tr '\n' '\0' | xargs -0 node --test --test-concurrency="$concurrency" --) || {
         echo -e "${RED}Tests failed in $dir${NC}"
         return 1
       }

--- a/plugins/work/scripts/workflows/lib/scripts/dev-check/dev-test.sh
+++ b/plugins/work/scripts/workflows/lib/scripts/dev-check/dev-test.sh
@@ -94,7 +94,10 @@ run_tests() {
       fi
       local abs_test_files
       abs_test_files=$(echo "$test_files" | sed "s|^|$dir/|")
-      (cd "$dir" && echo "$abs_test_files" | tr '\n' '\0' | xargs -0 node --test --) || {
+      # (GH-776) Default to one test process — node --test's CPU-count default
+      # with process isolation takes every core on a box running several
+      # concurrent agent sessions. Override via WORK_TEST_CONCURRENCY=<n>.
+      (cd "$dir" && echo "$abs_test_files" | tr '\n' '\0' | xargs -0 node --test --test-concurrency="${WORK_TEST_CONCURRENCY:-1}" --) || {
         echo -e "${RED}Tests failed in $dir${NC}"
         return 1
       }


### PR DESCRIPTION
Closes #776

## Existing Behavior

- `run-tests.sh` accepted positional arguments but silently ignored them — `pnpm test <file>` always ran the full ~500-file suite.
- `node --test` used its default concurrency (CPU count) with process isolation; on a 14-core box running multiple concurrent agent sessions this produced observed load of 39-49.
- `dev-test.sh` had no concurrency cap either, leaving the same CPU-saturation risk for developer dev-check runs.
- There was no way to assert the runner's file-selection or concurrency contract without actually spawning the full suite.

## Intended New Behavior

- Positional arguments passed to `run-tests.sh` become the file list verbatim; `.test-skip` filtering still applies to explicit args. No args triggers the existing full discovery.
- Local default concurrency is `--test-concurrency=1`; `WORK_TEST_CONCURRENCY=<n>` overrides it explicitly. CI stays pinned at 1 per GH-452 regardless of the override.
- `dev-test.sh` receives the same `--test-concurrency="${WORK_TEST_CONCURRENCY:-1}"` cap.
- `WORK_TEST_LIST_ONLY=1` prints the resolved file list and `concurrency=<n>` then exits without running the suite, making the contract unit-testable (6 new tests cover: positional args, full discovery, `.test-skip` on explicit args, local default=1, `WORK_TEST_CONCURRENCY` override, and CI pin).

## Dev Checks
- [ ] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Verify single-file targeting (the core fix):**

1. From the repo root, run: `pnpm test plugins/work/scripts/__tests__/run-tests-args.test.js`
2. Expected: only the 6 tests in that file execute; total runtime is under 2s; full suite is NOT triggered.

**Verify concurrency cap:**

1. `WORK_TEST_LIST_ONLY=1 bash plugins/work/scripts/run-tests.sh` — last output line should be `concurrency=1`.
2. `WORK_TEST_CONCURRENCY=4 WORK_TEST_LIST_ONLY=1 bash plugins/work/scripts/run-tests.sh` — last line should be `concurrency=4`.
3. `CI=true WORK_TEST_CONCURRENCY=8 WORK_TEST_LIST_ONLY=1 bash plugins/work/scripts/run-tests.sh` — last line should be `concurrency=1` (CI pin wins).

**Verify `.test-skip` still filters explicit args:**

1. Add a temp `.test-skip` containing one test filename.
2. Pass that filename as a positional arg: `WORK_TEST_LIST_ONLY=1 bash plugins/work/scripts/run-tests.sh path/to/skipped.test.js other.test.js`
3. Expected: only `other.test.js` appears in output; skipped file is omitted.

### Test Results

6 new tests in `plugins/work/scripts/__tests__/run-tests-args.test.js` cover the full contract. Verified end-to-end: `pnpm test <one file>` now runs 12 tests in 0.3s instead of triggering the full 500-file suite.
