### PR TITLE
feat(work): task attribution for parallel implement waves (GH-769)

### DIFF
--- a/plugins/work/scripts/workflows/lib/__tests__/outcome-verdicts.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/outcome-verdicts.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * outcome-verdicts.test.js — pins the shared flag vocabulary contract
+ * (GH-769 Task 2: `cross-task-attribution` flag kind).
+ *
+ * Every flag consumer (verdict engine, corpus validator, outcome gate,
+ * check flag gate) reads FLAG_KINDS / FLAG_KIND_VALUES from this one
+ * module, so the vocabulary itself must be pinned by test.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { FLAG_KINDS, FLAG_KIND_VALUES } = require('../outcome-verdicts');
+
+/** Pre-existing flag entries that must never change or disappear. */
+const PRE_EXISTING_FLAG_KINDS = Object.freeze({
+  noStructuredReporter: 'no-structured-reporter',
+  baseSetupFailed: 'base-setup-failed',
+  coverageUnavailable: 'coverage-unavailable',
+  coverageBelowThreshold: 'coverage-below-threshold',
+  tautology: 'tautology',
+  runnerUnknown: 'runner-unknown',
+  scopeResolutionFailed: 'scope-resolution-failed',
+  noTestFilesInDiff: 'no-test-files-in-diff',
+});
+
+test('FLAG_KINDS exposes crossTaskAttribution as "cross-task-attribution"', () => {
+  assert.equal(FLAG_KINDS.crossTaskAttribution, 'cross-task-attribution');
+});
+
+test('FLAG_KIND_VALUES contains "cross-task-attribution" exactly once', () => {
+  const occurrences = FLAG_KIND_VALUES.filter((value) => value === 'cross-task-attribution');
+  assert.equal(occurrences.length, 1);
+});
+
+test('FLAG_KINDS and FLAG_KIND_VALUES remain frozen', () => {
+  assert.equal(Object.isFrozen(FLAG_KINDS), true);
+  assert.equal(Object.isFrozen(FLAG_KIND_VALUES), true);
+});
+
+test('every pre-existing flag value is still present and unchanged', () => {
+  for (const [key, value] of Object.entries(PRE_EXISTING_FLAG_KINDS)) {
+    assert.equal(FLAG_KINDS[key], value);
+    assert.ok(FLAG_KIND_VALUES.includes(value));
+  }
+});
+
+test('FLAG_KIND_VALUES stays derived from FLAG_KINDS (no extras, no drift)', () => {
+  assert.deepEqual(FLAG_KIND_VALUES, Object.values(FLAG_KINDS));
+});

--- a/plugins/work/scripts/workflows/lib/outcome-verdicts.js
+++ b/plugins/work/scripts/workflows/lib/outcome-verdicts.js
@@ -44,6 +44,8 @@ const INVARIANTS = Object.freeze({
 /**
  * Flag kinds attached to UNVERIFIED advances (and to soft findings on
  * otherwise-advancing verdicts). Consumed by task_review and the check step.
+ * `cross-task-attribution` (GH-769) marks evidence whose scope overlaps a
+ * sibling task's owned surfaces.
  */
 const FLAG_KINDS = Object.freeze({
   noStructuredReporter: 'no-structured-reporter',
@@ -54,6 +56,7 @@ const FLAG_KINDS = Object.freeze({
   runnerUnknown: 'runner-unknown',
   scopeResolutionFailed: 'scope-resolution-failed',
   noTestFilesInDiff: 'no-test-files-in-diff',
+  crossTaskAttribution: 'cross-task-attribution',
 });
 
 /**

--- a/plugins/work/scripts/workflows/lib/replay-corpus/__tests__/index.test.js
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/__tests__/index.test.js
@@ -1,0 +1,132 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { loadCorpus, validateFixture } = require('..');
+const { FLAG_KIND_VALUES } = require('../../outcome-verdicts');
+
+/** A minimal fully-valid fixture (mirrors replay-corpus.test.js). */
+function validFixture(overrides = {}) {
+  return {
+    name: 'test-fixture',
+    incident: 'GH-999',
+    incidentClass: 7,
+    taskKind: 'tdd-code',
+    description: 'synthetic fixture for attribution validator tests',
+    observations: {
+      diff: { empty: false, filesChanged: ['src/a.js'], scopeGlobs: ['src/**'], outOfScope: [] },
+      deliverables: { promised: ['src/a.js'], missing: [] },
+      baseRun: { attempted: true, supported: true, outcome: 'fail', testsRan: 2, failures: 2 },
+      headRun: {
+        attempted: true,
+        supported: true,
+        outcome: 'pass',
+        testsRan: 2,
+        failures: 0,
+        exitCode: 0,
+        reporterKind: 'structured',
+      },
+      coverage: { supported: true, changedLineCoveragePct: 92 },
+    },
+    expected: { verdict: 'VERIFIED', rationale: 'all invariants hold' },
+    provenance: { issue: 'https://github.com/thomfilg/ai-plugin-work/issues/999' },
+    ...overrides,
+  };
+}
+
+/** A well-formed optional attribution block. */
+function validAttribution(overrides = {}) {
+  return {
+    supported: true,
+    mode: 'trailer',
+    taskId: 4,
+    foreignTasks: ['1'],
+    unattributedCount: 0,
+    ...overrides,
+  };
+}
+
+/** Build a fixture carrying an attribution block with the given overrides. */
+function fixtureWithAttribution(attributionOverrides = {}) {
+  const fixture = validFixture();
+  fixture.observations.attribution = validAttribution(attributionOverrides);
+  return fixture;
+}
+
+describe('replay-corpus — optional observations.attribution validation', () => {
+  it('accepts a fixture with a well-formed attribution block', () => {
+    assert.deepEqual(validateFixture(fixtureWithAttribution()), []);
+  });
+
+  it('still validates a fixture WITHOUT the attribution block', () => {
+    assert.deepEqual(validateFixture(validFixture()), []);
+  });
+
+  it("rejects mode 'branch' (must be trailer|none)", () => {
+    const errors = validateFixture(fixtureWithAttribution({ mode: 'branch' }));
+    assert.ok(
+      errors.some((e) => e.includes('observations.attribution.mode')),
+      `expected an observations.attribution.mode error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it("accepts mode 'none'", () => {
+    assert.deepEqual(validateFixture(fixtureWithAttribution({ mode: 'none' })), []);
+  });
+
+  it("rejects supported 'yes' (boolean required)", () => {
+    const errors = validateFixture(fixtureWithAttribution({ supported: 'yes' }));
+    assert.ok(
+      errors.some((e) => e.includes('observations.attribution.supported')),
+      `expected an observations.attribution.supported error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it("rejects taskId 'four' (integer or null required)", () => {
+    const errors = validateFixture(fixtureWithAttribution({ taskId: 'four' }));
+    assert.ok(
+      errors.some((e) => e.includes('observations.attribution.taskId')),
+      `expected an observations.attribution.taskId error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it('accepts taskId null', () => {
+    assert.deepEqual(validateFixture(fixtureWithAttribution({ taskId: null })), []);
+  });
+
+  it("rejects foreignTasks '1' (string array required)", () => {
+    const errors = validateFixture(fixtureWithAttribution({ foreignTasks: '1' }));
+    assert.ok(
+      errors.some((e) => e.includes('observations.attribution.foreignTasks')),
+      `expected an observations.attribution.foreignTasks error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it('rejects unattributedCount -1 (integer >= 0 required)', () => {
+    const errors = validateFixture(fixtureWithAttribution({ unattributedCount: -1 }));
+    assert.ok(
+      errors.some((e) => e.includes('observations.attribution.unattributedCount')),
+      `expected an observations.attribution.unattributedCount error, got: ${JSON.stringify(errors)}`
+    );
+  });
+
+  it("accepts the expected flag 'cross-task-attribution' in flag-value validation", () => {
+    assert.ok(FLAG_KIND_VALUES.includes('cross-task-attribution'));
+    const fixture = fixtureWithAttribution();
+    fixture.expected = {
+      verdict: 'UNVERIFIED',
+      flags: ['cross-task-attribution'],
+      rationale: 'evidence overlaps a sibling task',
+    };
+    assert.deepEqual(validateFixture(fixture), []);
+  });
+});
+
+describe('replay-corpus — corpus regression with attribution support', () => {
+  it('Replay corpus stays 100% green with the new fixture', () => {
+    const { fixtures, errors } = loadCorpus();
+    assert.deepEqual(errors, []);
+    assert.ok(fixtures.length >= 22, `expected >= 22 fixtures, got ${fixtures.length}`);
+  });
+});

--- a/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-720-cross-attributed-commits-resolve-cleanly.json
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/fixtures/gh-720-cross-attributed-commits-resolve-cleanly.json
@@ -1,0 +1,57 @@
+{
+  "name": "gh-720-cross-attributed-commits-resolve-cleanly",
+  "incident": "GH-720",
+  "incidentClass": 7,
+  "taskKind": "tdd-code",
+  "description": "Parallel implement wave shared one worktree and one branch: task 4 committed its own fix and test with a Work-Task:4 trailer, but a sibling task 1 committed into the same base..HEAD range with a Work-Task:1 trailer. The attribution collector partitions the range by trailer, so task 4's diff resolves cleanly to ITS OWN files only — a genuine, in-scope, base-fail/head-pass outcome. Because the range still contains a foreign-attributed sibling commit, the boundary degrades to UNVERIFIED with a cross-task-attribution mechanism-failure flag (never a hard block), naming task 1 as the leaked sibling.",
+  "observations": {
+    "diff": {
+      "empty": false,
+      "filesChanged": [
+        "factories/registryValidator/registryValidator.js",
+        "factories/registryValidator/__tests__/registryValidator.test.js"
+      ],
+      "scopeGlobs": ["factories/registryValidator/**"],
+      "outOfScope": []
+    },
+    "deliverables": {
+      "promised": ["factories/registryValidator/registryValidator.js"],
+      "missing": []
+    },
+    "baseRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "fail",
+      "testsRan": 3,
+      "failures": 3,
+      "notes": "task 4's attributed test fails on base — the validator did not exist before this task"
+    },
+    "headRun": {
+      "attempted": true,
+      "supported": true,
+      "outcome": "pass",
+      "testsRan": 3,
+      "failures": 0,
+      "exitCode": 0,
+      "reporterKind": "structured",
+      "notes": "task 4's attributed tests pass on head with a real structured count"
+    },
+    "coverage": { "supported": false, "changedLineCoveragePct": null },
+    "attribution": {
+      "supported": true,
+      "mode": "trailer",
+      "taskId": 4,
+      "foreignTasks": ["1"],
+      "unattributedCount": 0
+    }
+  },
+  "expected": {
+    "verdict": "UNVERIFIED",
+    "flags": ["cross-task-attribution"],
+    "rationale": "Task 4's diff resolves cleanly from its own Work-Task:4 commits (non-empty, in-scope, base-fail/head-pass), so there is no invariant violation. But the base..HEAD range contains a foreign commit attributed to task 1: attribution is a mechanism-failure flag, not a block, so the boundary degrades to UNVERIFIED and names the leaked sibling (task 1) for the operator."
+  },
+  "provenance": {
+    "issue": "https://github.com/thomfilg/ai-plugin-work/issues/720",
+    "notes": "Companion to gh-720-parallel-wave-contamination: that fixture shows the contaminated (empty) diff CONTRADICTED; this one shows the same wave AFTER attributed resolution — clean own diff plus the cross-task-attribution flag. Attribution flags never mask violations, so the CONTRADICTED sibling fixture is unaffected."
+  }
+}

--- a/plugins/work/scripts/workflows/lib/replay-corpus/index.js
+++ b/plugins/work/scripts/workflows/lib/replay-corpus/index.js
@@ -214,7 +214,39 @@ function validateIdentity(errors, fixture) {
   requireString(errors, fixture, 'description', 'fixture');
 }
 
-/** Validate the observations block (diff/deliverables/runs/coverage). */
+/** Legal `mode` values for the optional attribution block. */
+const ATTRIBUTION_MODES = Object.freeze(['trailer', 'none']);
+
+/**
+ * Validate the OPTIONAL observations.attribution block (GH-769). Absence is
+ * valid; when present it must be a well-formed object.
+ */
+function validateAttribution(errors, attribution) {
+  if (attribution === undefined) return;
+  if (!attribution || typeof attribution !== 'object' || Array.isArray(attribution)) {
+    errors.push('observations.attribution must be an object when present');
+    return;
+  }
+  pushIf(
+    errors,
+    typeof attribution.supported !== 'boolean',
+    'observations.attribution.supported must be a boolean'
+  );
+  requireEnum(errors, attribution.mode, ATTRIBUTION_MODES, 'observations.attribution.mode');
+  pushIf(
+    errors,
+    !(attribution.taskId === null || Number.isInteger(attribution.taskId)),
+    'observations.attribution.taskId must be an integer or null'
+  );
+  requireStringArray(errors, attribution, 'foreignTasks', 'observations.attribution');
+  pushIf(
+    errors,
+    !Number.isInteger(attribution.unattributedCount) || attribution.unattributedCount < 0,
+    'observations.attribution.unattributedCount must be an integer >= 0'
+  );
+}
+
+/** Validate the observations block (diff/deliverables/runs/coverage/attribution). */
 function validateObservations(errors, obs) {
   if (!obs || typeof obs !== 'object') {
     errors.push('observations must be an object');
@@ -225,6 +257,7 @@ function validateObservations(errors, obs) {
   validateRun(errors, obs.baseRun, 'observations.baseRun');
   validateHeadRun(errors, obs.headRun);
   validateCoverage(errors, obs.coverage);
+  validateAttribution(errors, obs.attribution);
 }
 
 /**
@@ -306,6 +339,7 @@ module.exports = {
   FIXTURES_DIR,
   RUN_OUTCOMES,
   REPORTER_KINDS,
+  ATTRIBUTION_MODES,
   validateFixture,
   loadCorpus,
 };

--- a/plugins/work/scripts/workflows/task-verify/__tests__/attribution-live.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/attribution-live.test.js
@@ -1,0 +1,184 @@
+'use strict';
+
+/**
+ * Two-task wave integration test (GH-769 Task 10).
+ *
+ * A live temp repo where two tasks commit interleaved (order 1,2,1,2) into one
+ * shared worktree, each stamping its own `Work-Task` trailer. Driven through
+ * the REAL entrypoints (buildObservations + observeBoundary + evaluate), this
+ * proves the end-to-end attribution contract shipped by Tasks 1/3/7/9:
+ *   - each task's resolved diff is disjoint and contains only its own files
+ *   - each attribution.foreignTasks names exactly the sibling
+ *   - evaluate yields UNVERIFIED with ['cross-task-attribution'] (clean own
+ *     work + the mechanism-failure wave flag, never a block)
+ *
+ * No production file is modified here — this suite pins already-shipped
+ * behavior.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildObservations } = require('../observe');
+const { observeBoundary } = require('../boundary');
+const { evaluate } = require('../verdict-engine');
+const { VERDICTS } = require('../../lib/outcome-verdicts');
+
+let ROOT;
+let REPO;
+let TASKS;
+let baseSha;
+
+function git(args) {
+  return execFileSync('git', ['-C', REPO, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function write(rel, content) {
+  const full = path.join(REPO, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function commit(message, trailerValue) {
+  git(['add', '-A']);
+  git(['commit', '-q', '-m', message, '--trailer', `Work-Task: ${trailerValue}`]);
+  return git(['rev-parse', 'HEAD']);
+}
+
+// docs kind keeps the harness fast (no derived-test execution); the diff-only
+// attribution mechanics are identical across kinds.
+const TASKS_MD = [
+  '# Tasks',
+  '',
+  '## Task 1 — module A',
+  '### Type',
+  'docs',
+  '### Files in scope',
+  '- src/a.js',
+  '- src/__tests__/a.test.js',
+  '',
+  '## Task 2 — module B',
+  '### Type',
+  'docs',
+  '### Files in scope',
+  '- src/b.js',
+  '- src/__tests__/b.test.js',
+  '',
+].join('\n');
+
+before(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'attribution-live-'));
+  REPO = path.join(ROOT, 'repo');
+  TASKS = path.join(ROOT, 'tasks');
+  fs.mkdirSync(REPO);
+  fs.mkdirSync(TASKS);
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+
+  // Base commit: buggy modules A and B + a node --test package.
+  write('package.json', JSON.stringify({ name: 't', scripts: { test: 'node --test' } }));
+  write('src/a.js', 'module.exports = { a: () => 0 };\n');
+  write('src/b.js', 'module.exports = { b: () => 0 };\n');
+  git(['add', '-A']);
+  git(['commit', '-qm', 'base: buggy A and B']);
+  baseSha = git(['rev-parse', 'HEAD']);
+
+  fs.writeFileSync(path.join(TASKS, 'tasks.md'), TASKS_MD);
+  fs.writeFileSync(path.join(TASKS, '.last-commit-sha'), baseSha);
+
+  // Interleaved wave: task 1 fixes A + authors a.test.js; task 2 fixes B +
+  // authors b.test.js — order 1,2,1,2 to force range interleaving.
+  write('src/a.js', 'module.exports = { a: () => 1 };\n');
+  commit('t1: fix a', '1');
+  write('src/b.js', 'module.exports = { b: () => 1 };\n');
+  commit('t2: fix b', '2');
+  write('src/__tests__/a.test.js', "require('node:test');\n");
+  commit('t1: author a.test', '1');
+  write('src/__tests__/b.test.js', "require('node:test');\n");
+  commit('t2: author b.test', '2');
+});
+
+after(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+function observeTask(taskNum) {
+  return buildObservations({
+    repoDir: REPO,
+    baseRef: baseSha,
+    scopeGlobs: ['src/**'],
+    taskKind: 'docs',
+    taskNum,
+    baseWorktreeDir: path.join(ROOT, `bwt-${taskNum}`),
+  });
+}
+
+describe('two-task wave — disjoint correctly-attributed boundaries (GH-769)', () => {
+  it('the shared range contains both tasks interleaved (harness sanity)', () => {
+    const log = git(['log', '--format=%s', `${baseSha}..HEAD`]);
+    assert.match(log, /t1: /);
+    assert.match(log, /t2: /);
+    assert.equal(log.split('\n').length, 4);
+  });
+
+  it('task 1 resolves to ITS files only', () => {
+    const obs = observeTask(1);
+    assert.deepEqual(obs.diff.filesChanged, ['src/__tests__/a.test.js', 'src/a.js']);
+    assert.equal(obs.attribution.taskId, 1);
+  });
+
+  it('task 2 resolves to ITS files only', () => {
+    const obs = observeTask(2);
+    assert.deepEqual(obs.diff.filesChanged, ['src/__tests__/b.test.js', 'src/b.js']);
+    assert.equal(obs.attribution.taskId, 2);
+  });
+
+  it('the two resolved diffs are disjoint — zero cross-task files', () => {
+    const one = new Set(observeTask(1).diff.filesChanged);
+    const two = new Set(observeTask(2).diff.filesChanged);
+    for (const f of one) assert.ok(!two.has(f), `${f} leaked into both diffs`);
+    assert.ok(![...one].some((f) => f.includes('/b')));
+    assert.ok(![...two].some((f) => f.includes('/a')));
+  });
+
+  it('each attribution.foreignTasks names exactly the sibling', () => {
+    assert.deepEqual(observeTask(1).attribution.foreignTasks, ['2']);
+    assert.deepEqual(observeTask(2).attribution.foreignTasks, ['1']);
+  });
+
+  it('evaluate yields UNVERIFIED + [cross-task-attribution] for each task', () => {
+    for (const num of [1, 2]) {
+      const result = evaluate(observeTask(num), 'docs');
+      assert.equal(result.verdict, VERDICTS.unverified, result.reasons.join(' | '));
+      assert.deepEqual(result.flags, ['cross-task-attribution']);
+      assert.equal(result.exit, null, 'attribution never blocks');
+      assert.ok(
+        result.reasons.some((r) => r.includes(String(num))),
+        'reason names the expected task id'
+      );
+    }
+  });
+
+  it('the real observeBoundary entrypoint carries the attributed diff and flag', () => {
+    const out = observeBoundary({
+      repoDir: REPO,
+      tasksDir: TASKS,
+      taskNum: 2,
+      taskType: 'docs',
+      baseWorktreeDir: path.join(ROOT, 'bwt-boundary'),
+    });
+    assert.ok(!out.error, out.error);
+    assert.deepEqual(out.observations.diff.filesChanged, ['src/__tests__/b.test.js', 'src/b.js']);
+    assert.deepEqual(out.observations.attribution.foreignTasks, ['1']);
+    assert.equal(out.result.verdict, VERDICTS.unverified);
+    assert.deepEqual(out.result.flags, ['cross-task-attribution']);
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/__tests__/boundary.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/boundary.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+/**
+ * boundary.js taskNum-threading unit tests (GH-769 Task 9).
+ *
+ * observeBoundary must thread its existing taskNum into buildObservations so a
+ * live boundary resolves the diff from THIS task's attributed commits. Driven
+ * through the real entrypoint against a temp repo + synthetic tasks dir.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { observeBoundary } = require('../boundary');
+
+let ROOT;
+let REPO;
+let TASKS;
+let baseSha;
+
+function git(args) {
+  return execFileSync('git', ['-C', REPO, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function write(rel, content) {
+  const full = path.join(REPO, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function commit(message, trailerValue) {
+  git(['add', '-A']);
+  const args = ['commit', '-q', '--allow-empty', '-m', message];
+  if (trailerValue !== undefined) args.push('--trailer', `Work-Task: ${trailerValue}`);
+  git(args);
+  return git(['rev-parse', 'HEAD']);
+}
+
+const TASKS_MD = [
+  '# Tasks',
+  '',
+  '## Task 1 — module A',
+  '',
+  '### Type',
+  'docs',
+  '',
+  '### Files in scope',
+  '- `a.md`',
+  '',
+  '## Task 2 — module B',
+  '',
+  '### Type',
+  'docs',
+  '',
+  '### Files in scope',
+  '- `b.md`',
+  '',
+].join('\n');
+
+before(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-attr-'));
+  REPO = path.join(ROOT, 'repo');
+  TASKS = path.join(ROOT, 'tasks');
+  fs.mkdirSync(REPO);
+  fs.mkdirSync(TASKS);
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+
+  write('base.md', 'base\n');
+  baseSha = commit('base');
+  fs.writeFileSync(path.join(TASKS, 'tasks.md'), TASKS_MD);
+  fs.writeFileSync(path.join(TASKS, '.last-commit-sha'), baseSha);
+
+  // Interleaved Work-Task:1 / Work-Task:2 (order 1,2,1,2).
+  write('a.md', 'a1\n');
+  commit('t1 first', '1');
+  write('b.md', 'b1\n');
+  commit('t2 first', '2');
+  write('a.md', 'a2\n');
+  commit('t1 second', '1');
+  write('b.md', 'b2\n');
+  commit('t2 second', '2');
+});
+
+after(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('observeBoundary taskNum threading (GH-769)', () => {
+  it('resolves task 2 to its attributed files with foreignTasks naming task 1', () => {
+    const out = observeBoundary({
+      repoDir: REPO,
+      tasksDir: TASKS,
+      taskNum: 2,
+      taskType: 'docs',
+      baseWorktreeDir: path.join(ROOT, 'bwt2'),
+    });
+    assert.ok(!out.error, `unexpected error: ${out.error}`);
+    assert.equal(out.observations.attribution.taskId, 2);
+    assert.deepEqual(out.observations.attribution.foreignTasks, ['1']);
+    assert.deepEqual(out.observations.diff.filesChanged, ['b.md']);
+    assert.ok(!out.observations.diff.filesChanged.includes('a.md'));
+  });
+
+  it('resolves task 1 to its attributed files, disjoint from task 2', () => {
+    const out = observeBoundary({
+      repoDir: REPO,
+      tasksDir: TASKS,
+      taskNum: 1,
+      taskType: 'docs',
+      baseWorktreeDir: path.join(ROOT, 'bwt1'),
+    });
+    assert.deepEqual(out.observations.diff.filesChanged, ['a.md']);
+    assert.deepEqual(out.observations.attribution.foreignTasks, ['2']);
+  });
+
+  it('a serial repo (no trailers) keeps the legacy diff through the same entrypoint', () => {
+    const sRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'boundary-serial-'));
+    const sRepo = path.join(sRoot, 'repo');
+    const sTasks = path.join(sRoot, 'tasks');
+    fs.mkdirSync(sRepo);
+    fs.mkdirSync(sTasks);
+    const sg = (args) =>
+      execFileSync('git', ['-C', sRepo, ...args], {
+        encoding: 'utf-8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      }).trim();
+    sg(['init', '-q']);
+    sg(['config', 'user.email', 'test@example.com']);
+    sg(['config', 'user.name', 'Test']);
+    fs.writeFileSync(path.join(sRepo, 'base.md'), 'base\n');
+    sg(['add', '-A']);
+    sg(['commit', '-qm', 'base']);
+    const sBase = sg(['rev-parse', 'HEAD']);
+    fs.writeFileSync(path.join(sTasks, 'tasks.md'), TASKS_MD);
+    fs.writeFileSync(path.join(sTasks, '.last-commit-sha'), sBase);
+    fs.writeFileSync(path.join(sRepo, 'a.md'), 'a\n');
+    fs.writeFileSync(path.join(sRepo, 'b.md'), 'b\n');
+    sg(['add', '-A']);
+    sg(['commit', '-qm', 'no trailer work']);
+
+    const out = observeBoundary({
+      repoDir: sRepo,
+      tasksDir: sTasks,
+      taskNum: 1,
+      taskType: 'docs',
+      baseWorktreeDir: path.join(sRoot, 'bwt'),
+    });
+    assert.equal(out.observations.attribution.mode, 'none');
+    assert.deepEqual(out.observations.diff.filesChanged.sort(), ['a.md', 'b.md']);
+    fs.rmSync(sRoot, { recursive: true, force: true });
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/__tests__/observe.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/observe.test.js
@@ -1,0 +1,169 @@
+'use strict';
+
+/**
+ * observe.js attributed-diff resolution unit tests (GH-769 Task 7).
+ *
+ * Live temp repos (mkdtemp + `git -C`, mirroring observe-live.test.js:26-60)
+ * prove the three resolution rules:
+ *   (a) serial repo, no Work-Task trailers → legacy base..HEAD diff, mode none
+ *   (b) interleaved Work-Task:4 / Work-Task:1 → task 4's attributed files only
+ *   (c) unresolvable base for the trailer read → legacy diff, supported false
+ *   (d) taskNum omitted → no attribution key, behavior unchanged
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { buildObservations } = require('../observe');
+
+// ---------------------------------------------------------------------------
+// Temp-repo harness (mirrors observe-live.test.js)
+// ---------------------------------------------------------------------------
+
+function makeRepo() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'observe-attr-'));
+  const repo = path.join(root, 'repo');
+  fs.mkdirSync(repo);
+  const g = (args) =>
+    execFileSync('git', ['-C', repo, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  g(['init', '-q']);
+  g(['config', 'user.email', 'test@example.com']);
+  g(['config', 'user.name', 'Test']);
+  const write = (rel, content) => {
+    const full = path.join(repo, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, content);
+  };
+  const commit = (message, trailerValue) => {
+    g(['add', '-A']);
+    const args = ['commit', '-q', '--allow-empty', '-m', message];
+    if (trailerValue !== undefined) args.push('--trailer', `Work-Task: ${trailerValue}`);
+    g(args);
+    return g(['rev-parse', 'HEAD']);
+  };
+  return { root, repo, g, write, commit };
+}
+
+const KIND = 'docs'; // profile that requires no test run — keeps the harness fast
+
+// ---------------------------------------------------------------------------
+// Rule (a): serial repo, no trailers → legacy diff, mode none
+// ---------------------------------------------------------------------------
+
+describe('buildObservations attributed resolution', () => {
+  let serial;
+  let serialBase;
+  let wave;
+  let waveBase;
+
+  before(() => {
+    serial = makeRepo();
+    serial.write('base.txt', 'b\n');
+    serialBase = serial.commit('base');
+    serial.write('src/a.md', 'a\n');
+    serial.commit('add a'); // no trailer
+    serial.write('src/b.md', 'b\n');
+    serial.commit('add b'); // no trailer
+
+    wave = makeRepo();
+    wave.write('base.txt', 'b\n');
+    waveBase = wave.commit('base');
+    // Interleaved 4,1,4,1
+    wave.write('own-a.md', 'a\n');
+    wave.commit('t4 first', '4');
+    wave.write('foreign-1.md', 'f\n');
+    wave.commit('t1 first', '1');
+    wave.write('own-b.md', 'b\n');
+    wave.commit('t4 second', 'task4');
+    wave.write('foreign-2.md', 'f2\n');
+    wave.commit('t1 second', 'task 1');
+  });
+
+  after(() => {
+    fs.rmSync(serial.root, { recursive: true, force: true });
+    fs.rmSync(wave.root, { recursive: true, force: true });
+  });
+
+  it('(a) serial repo with taskNum but no trailers keeps the legacy diff, mode none', () => {
+    const obs = buildObservations({
+      repoDir: serial.repo,
+      baseRef: serialBase,
+      scopeGlobs: ['src/**'],
+      taskKind: KIND,
+      taskNum: 4,
+      baseWorktreeDir: path.join(serial.root, 'bwt'),
+    });
+    assert.deepEqual(obs.diff.filesChanged.sort(), ['src/a.md', 'src/b.md']);
+    assert.equal(obs.attribution.supported, true);
+    assert.equal(obs.attribution.mode, 'none');
+    assert.deepEqual(obs.attribution.foreignTasks, []);
+  });
+
+  it('(b) interleaved wave resolves task 4 to its attributed files only', () => {
+    const obs = buildObservations({
+      repoDir: wave.repo,
+      baseRef: waveBase,
+      scopeGlobs: ['**'],
+      taskKind: KIND,
+      taskNum: 4,
+      baseWorktreeDir: path.join(wave.root, 'bwt4'),
+    });
+    assert.deepEqual(obs.diff.filesChanged, ['own-a.md', 'own-b.md']);
+    assert.equal(obs.diff.empty, false);
+    assert.equal(obs.attribution.mode, 'trailer');
+    assert.equal(obs.attribution.taskId, 4);
+    assert.deepEqual(obs.attribution.foreignTasks, ['1']);
+    // No sibling file leaks into task 4's observed diff.
+    assert.ok(!obs.diff.filesChanged.includes('foreign-1.md'));
+    assert.ok(!obs.diff.filesChanged.includes('foreign-2.md'));
+  });
+
+  it('(b2) the sibling task 1 resolves to ITS files only, disjoint from task 4', () => {
+    const obs = buildObservations({
+      repoDir: wave.repo,
+      baseRef: waveBase,
+      scopeGlobs: ['**'],
+      taskKind: KIND,
+      taskNum: 1,
+      baseWorktreeDir: path.join(wave.root, 'bwt1'),
+    });
+    assert.deepEqual(obs.diff.filesChanged, ['foreign-1.md', 'foreign-2.md']);
+    assert.deepEqual(obs.attribution.foreignTasks, ['4']);
+  });
+
+  it('(c) unresolvable base for the attribution read degrades without throwing', () => {
+    // Collector fails on the bogus ref → supported:false; the observe path
+    // stays fail-open (no throw, degraded attribution, empty legacy diff).
+    const obs = buildObservations({
+      repoDir: wave.repo,
+      baseRef: 'no-such-ref',
+      scopeGlobs: ['**'],
+      taskKind: KIND,
+      taskNum: 4,
+      baseWorktreeDir: path.join(wave.root, 'bwtc'),
+      headRef: waveBase,
+    });
+    assert.equal(obs.attribution.supported, false);
+    assert.equal(obs.attribution.mode, 'none');
+    assert.ok(Array.isArray(obs.diff.filesChanged));
+  });
+
+  it('(d) taskNum omitted → no attribution key, byte-for-byte legacy behavior', () => {
+    const withNum = buildObservations({
+      repoDir: serial.repo,
+      baseRef: serialBase,
+      scopeGlobs: ['src/**'],
+      taskKind: KIND,
+      baseWorktreeDir: path.join(serial.root, 'bwt-d'),
+    });
+    assert.equal('attribution' in withNum, false);
+    assert.deepEqual(withNum.diff.filesChanged.sort(), ['src/a.md', 'src/b.md']);
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/__tests__/outcome-gate.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/outcome-gate.test.js
@@ -210,3 +210,59 @@ describe('outcome-gate (GH-756)', () => {
     assert.equal(h.retries.length, 0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// GH-769: attribution surfaces in the outcome-gate audit meta.
+// ---------------------------------------------------------------------------
+
+function readVerifyRow() {
+  const rows = JSON.parse(fs.readFileSync(path.join(TASKS_DIR, '.work-actions.json'), 'utf8'));
+  return rows.filter((r) => r.action === 'task-verify').at(-1);
+}
+
+describe('outcome-gate attribution audit meta (GH-769)', () => {
+  it('audit meta carries the attribution block when observations include one', () => {
+    const h = makeHarness();
+    const attribution = {
+      supported: true,
+      mode: 'trailer',
+      taskId: 4,
+      foreignTasks: ['1'],
+      unattributedCount: 0,
+      attributedFiles: ['src/calc.js'],
+    };
+    const boundary = {
+      observations: { derivedTests: { files: [], runner: 'none' }, attribution },
+      result: {
+        verdict: VERDICTS.unverified,
+        violatedInvariants: [],
+        flags: ['cross-task-attribution'],
+        exit: null,
+        reasons: ['attribution: range contains commits attributed to task(s) 1 (expected task 4)'],
+      },
+    };
+    const outcome = runOutcomeGate(h.input, { observe: () => boundary });
+    assert.equal(outcome.advance, true);
+    assert.deepEqual(outcome.flags, ['cross-task-attribution']);
+    const meta = readVerifyRow().meta;
+    assert.deepEqual(meta.attribution, attribution);
+    // Flag still flows through recordOutcomeFlags unchanged.
+    assert.deepEqual(h.ws.outcomeFlags[0].flags, ['cross-task-attribution']);
+  });
+
+  it('audit meta omits the attribution key when observations carry none', () => {
+    const h = makeHarness();
+    const boundary = {
+      observations: { derivedTests: { files: [], runner: 'none' } },
+      result: {
+        verdict: VERDICTS.verified,
+        violatedInvariants: [],
+        flags: [],
+        exit: null,
+        reasons: [],
+      },
+    };
+    runOutcomeGate(h.input, { observe: () => boundary });
+    assert.equal('attribution' in readVerifyRow().meta, false);
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/__tests__/shadow.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/shadow.test.js
@@ -155,4 +155,92 @@ describe('task-verify shadow mode (GH-755)', () => {
     assert.equal(audit.rows.length, 1);
     assert.match(audit.rows[0].action, /task-verify-shadow-error/);
   });
+
+  it('serial observations audit a mode:none attribution block naming no foreign task', () => {
+    const audit = collectingAudit();
+    maybeRunShadow(
+      {
+        safeName: 'TEST-SHADOW-1',
+        tasksDir: TASKS_DIR,
+        taskNum: 1,
+        taskType: 'docs',
+        incumbent: 'advance',
+        repoDir: REPO,
+      },
+      { env: { WORK_TDD_MODE: 'shadow' }, appendAudit: audit.appendAudit }
+    );
+    // The serial repo carries no Work-Task trailers, but taskNum threading
+    // still produces a mode:'none' attribution block; it is present yet names
+    // no foreign task. The audit surfaces it verbatim (both-ids triageable).
+    assert.equal('attribution' in audit.rows[0].meta, true);
+    assert.equal(audit.rows[0].meta.attribution.mode, 'none');
+    assert.deepEqual(audit.rows[0].meta.attribution.foreignTasks, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GH-769: attribution surfaces in shadow audit meta for a wave repo.
+// ---------------------------------------------------------------------------
+
+describe('task-verify shadow mode attribution audit meta (GH-769)', () => {
+  let wROOT;
+  let wREPO;
+  let wTASKS;
+
+  function wgit(args) {
+    return execFileSync('git', ['-C', wREPO, ...args], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  }
+
+  before(() => {
+    wROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'shadow-attr-'));
+    wREPO = path.join(wROOT, 'repo');
+    wTASKS = path.join(wROOT, 'tasks', 'TEST-WAVE');
+    fs.mkdirSync(wREPO, { recursive: true });
+    fs.mkdirSync(wTASKS, { recursive: true });
+    wgit(['init', '-q']);
+    wgit(['config', 'user.email', 't@example.com']);
+    wgit(['config', 'user.name', 'T']);
+    fs.writeFileSync(path.join(wREPO, 'base.md'), 'base\n');
+    wgit(['add', '-A']);
+    wgit(['commit', '-qm', 'base']);
+    const wBase = wgit(['rev-parse', 'HEAD']);
+    fs.writeFileSync(path.join(wTASKS, '.last-commit-sha'), wBase);
+    fs.writeFileSync(
+      path.join(wTASKS, 'tasks.md'),
+      ['## Task 2 — module B', '### Type', 'docs', '### Files in scope', '- b.md', ''].join('\n')
+    );
+    // Interleaved Work-Task:1 / Work-Task:2.
+    fs.writeFileSync(path.join(wREPO, 'a.md'), 'a\n');
+    wgit(['add', '-A']);
+    wgit(['commit', '-qm', 't1', '--trailer', 'Work-Task: 1']);
+    fs.writeFileSync(path.join(wREPO, 'b.md'), 'b\n');
+    wgit(['add', '-A']);
+    wgit(['commit', '-qm', 't2', '--trailer', 'Work-Task: 2']);
+  });
+
+  after(() => {
+    fs.rmSync(wROOT, { recursive: true, force: true });
+  });
+
+  it('audit meta carries the attribution block naming both task ids', () => {
+    const audit = collectingAudit();
+    maybeRunShadow(
+      {
+        safeName: 'TEST-WAVE',
+        tasksDir: wTASKS,
+        taskNum: 2,
+        taskType: 'docs',
+        incumbent: 'advance',
+        repoDir: wREPO,
+      },
+      { env: { WORK_TDD_MODE: 'shadow' }, appendAudit: audit.appendAudit }
+    );
+    const meta = audit.rows[0].meta;
+    assert.equal(meta.attribution.taskId, 2);
+    assert.deepEqual(meta.attribution.foreignTasks, ['1']);
+    assert.ok(meta.flags.includes('cross-task-attribution'));
+  });
 });

--- a/plugins/work/scripts/workflows/task-verify/__tests__/verdict-engine.test.js
+++ b/plugins/work/scripts/workflows/task-verify/__tests__/verdict-engine.test.js
@@ -133,3 +133,91 @@ describe('verdict-engine (GH-755) — flags and thresholds', () => {
     assert.notEqual(r.verdict, VERDICTS.contradicted);
   });
 });
+
+describe('verdict-engine (GH-769) — cross-task attribution flags', () => {
+  it('Cross-attributed range emits a mechanism-failure flag, not a block', () => {
+    const r = evaluate(
+      {
+        ...baseObservations(),
+        attribution: {
+          supported: true,
+          mode: 'trailer',
+          taskId: 4,
+          foreignTasks: ['1'],
+          unattributedCount: 0,
+        },
+      },
+      'tdd-code'
+    );
+    assert.equal(r.verdict, VERDICTS.unverified);
+    assert.deepEqual(r.flags, ['cross-task-attribution']);
+    assert.deepEqual(r.violatedInvariants, [], 'attribution is never an invariant violation');
+    assert.equal(r.exit, null, 'attribution never produces a typed exit');
+    const reason = r.reasons.find((x) => x.includes('attribution'));
+    assert.ok(reason, 'a reason names the attribution problem');
+    assert.match(reason, /4/, 'reason names the expected task id');
+    assert.match(reason, /1/, 'reason names the foreign task id');
+  });
+
+  it('empty foreignTasks emits no attribution flag', () => {
+    const r = evaluate(
+      {
+        ...baseObservations(),
+        attribution: {
+          supported: true,
+          mode: 'trailer',
+          taskId: 4,
+          foreignTasks: [],
+          unattributedCount: 0,
+        },
+      },
+      'tdd-code'
+    );
+    assert.equal(r.verdict, VERDICTS.verified);
+    assert.deepEqual(r.flags, []);
+  });
+
+  it('unsupported attribution collector emits no attribution flag', () => {
+    const r = evaluate(
+      {
+        ...baseObservations(),
+        attribution: {
+          supported: false,
+          mode: 'none',
+          taskId: null,
+          foreignTasks: [],
+          unattributedCount: 0,
+        },
+      },
+      'tdd-code'
+    );
+    assert.equal(r.verdict, VERDICTS.verified);
+    assert.deepEqual(r.flags, []);
+  });
+
+  it('absent attribution block behaves identically to today', () => {
+    const r = evaluate(baseObservations(), 'tdd-code');
+    assert.equal(r.verdict, VERDICTS.verified);
+    assert.deepEqual(r.flags, []);
+    assert.equal(r.exit, null);
+  });
+
+  it('attribution flags never mask violations — CONTRADICTED stays CONTRADICTED', () => {
+    const r = evaluate(
+      {
+        ...baseObservations({ headRun: { outcome: 'fail', failures: 1 } }),
+        attribution: {
+          supported: true,
+          mode: 'trailer',
+          taskId: 4,
+          foreignTasks: ['1'],
+          unattributedCount: 0,
+        },
+      },
+      'tdd-code'
+    );
+    assert.equal(r.verdict, VERDICTS.contradicted);
+    assert.deepEqual(r.violatedInvariants, ['I4']);
+    assert.notEqual(r.exit, null);
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/boundary.js
+++ b/plugins/work/scripts/workflows/task-verify/boundary.js
@@ -61,6 +61,11 @@ function observeBoundary({ repoDir, tasksDir, taskNum, taskType, baseRef, baseWo
     baseRef: resolvedBase,
     scopeGlobs: taskScopeGlobs(tasksDir, taskNum),
     taskKind: taskType,
+    // GH-769: thread the task number so the observer resolves the diff from
+    // THIS task's attributed commits (a `Work-Task` trailer partitions a
+    // parallel wave's shared range). Serial repos (no trailers) fall through
+    // to the legacy diff inside buildObservations.
+    taskNum,
     baseWorktreeDir:
       baseWorktreeDir || path.join(tasksDir, `.task-verify-base-${path.basename(repoDir)}`),
   });

--- a/plugins/work/scripts/workflows/task-verify/collect/__tests__/attribution.test.js
+++ b/plugins/work/scripts/workflows/task-verify/collect/__tests__/attribution.test.js
@@ -1,0 +1,293 @@
+'use strict';
+
+/**
+ * Attribution collector unit tests (GH-769 Task 1).
+ * Covers trailer-value parsing, commit partitioning, attributed file union,
+ * and the fail-open `resolveAttribution` entrypoint against a live temp repo.
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+  WORK_TASK_TRAILER,
+  parseWorkTaskValue,
+  commitsInRange,
+  partitionForTask,
+  changedFilesForCommits,
+  resolveAttribution,
+} = require('../attribution');
+
+// ---------------------------------------------------------------------------
+// Temp-repo helpers (mirrors observe-live.test.js setup)
+// ---------------------------------------------------------------------------
+
+let ROOT;
+let REPO;
+let baseSha;
+/** sha per commit label for range assertions */
+const SHAS = {};
+
+function git(args) {
+  return execFileSync('git', ['-C', REPO, ...args], {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function write(rel, content) {
+  const full = path.join(REPO, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+/** Commit all pending changes; optional Work-Task trailer value. */
+function commit(message, trailerValue) {
+  git(['add', '-A']);
+  const args = ['commit', '-q', '--allow-empty', '-m', message];
+  if (trailerValue !== undefined) {
+    args.push('--trailer', `${WORK_TASK_TRAILER}: ${trailerValue}`);
+  }
+  git(args);
+  return git(['rev-parse', 'HEAD']);
+}
+
+before(() => {
+  ROOT = fs.mkdtempSync(path.join(os.tmpdir(), 'attribution-test-'));
+  REPO = path.join(ROOT, 'repo');
+  fs.mkdirSync(REPO);
+  git(['init', '-q']);
+  git(['config', 'user.email', 'test@example.com']);
+  git(['config', 'user.name', 'Test']);
+
+  write('base.txt', 'base\n');
+  baseSha = commit('base commit');
+
+  // Interleaved attributed + unattributed commits.
+  write('own-a.txt', 'a\n');
+  SHAS.ownA = commit('task4 first', '4');
+
+  write('foreign-1.txt', 'f\n');
+  SHAS.foreign1 = commit('task1 work', 'task 1');
+
+  write('own-b.txt', 'b\n');
+  write('own-a.txt', 'a2\n');
+  SHAS.ownB = commit('task4 second', 'task4');
+
+  write('junk.txt', 'j\n');
+  SHAS.junk = commit('hostile trailer', '../../etc/passwd');
+
+  write('plain.txt', 'p\n');
+  SHAS.plain = commit('no trailer at all');
+});
+
+after(() => {
+  fs.rmSync(ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// 1.1 parseWorkTaskValue
+// ---------------------------------------------------------------------------
+
+describe('parseWorkTaskValue', () => {
+  it('accepts canonical and tolerated forms', () => {
+    assert.equal(parseWorkTaskValue('4'), 4);
+    assert.equal(parseWorkTaskValue('task4'), 4);
+    assert.equal(parseWorkTaskValue('task 4'), 4);
+    assert.equal(parseWorkTaskValue('TASK 4'), 4);
+    assert.equal(parseWorkTaskValue('  12  '), 12);
+    assert.equal(parseWorkTaskValue('0042'), 42);
+  });
+
+  it('rejects hostile or malformed values as null', () => {
+    assert.equal(parseWorkTaskValue(''), null);
+    assert.equal(parseWorkTaskValue('4x'), null);
+    assert.equal(parseWorkTaskValue('12345'), null); // five digits
+    assert.equal(parseWorkTaskValue('../../etc/passwd'), null);
+    assert.equal(parseWorkTaskValue('$(rm -rf /)'), null);
+    assert.equal(parseWorkTaskValue('not-a-task'), null);
+    assert.equal(parseWorkTaskValue('task'), null);
+    assert.equal(parseWorkTaskValue(null), null);
+    assert.equal(parseWorkTaskValue(undefined), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1.1 WORK_TASK_TRAILER
+// ---------------------------------------------------------------------------
+
+describe('WORK_TASK_TRAILER', () => {
+  it('is the literal trailer key', () => {
+    assert.equal(WORK_TASK_TRAILER, 'Work-Task');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1.1 partitionForTask
+// ---------------------------------------------------------------------------
+
+describe('partitionForTask', () => {
+  it('keeps own shas in order, dedupes+sorts foreign ids, counts unattributed', () => {
+    const commits = [
+      { sha: 'a1', taskId: 4 },
+      { sha: 'b2', taskId: 2 },
+      { sha: 'c3', taskId: null },
+      { sha: 'd4', taskId: 4 },
+      { sha: 'e5', taskId: 10 },
+      { sha: 'f6', taskId: 2 },
+      { sha: 'g7', taskId: null },
+    ];
+    const out = partitionForTask(commits, 4);
+    assert.deepEqual(out.own, ['a1', 'd4']);
+    assert.deepEqual(out.foreignTasks, ['2', '10']);
+    assert.equal(out.unattributedCount, 2);
+  });
+
+  it('handles an empty commit list', () => {
+    const out = partitionForTask([], 4);
+    assert.deepEqual(out.own, []);
+    assert.deepEqual(out.foreignTasks, []);
+    assert.equal(out.unattributedCount, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1.1 commitsInRange (live repo)
+// ---------------------------------------------------------------------------
+
+describe('commitsInRange', () => {
+  it('lists commits oldest-first with their attributed task id', () => {
+    const commits = commitsInRange(REPO, baseSha, 'HEAD');
+    assert.deepEqual(
+      commits.map((c) => c.sha),
+      [SHAS.ownA, SHAS.foreign1, SHAS.ownB, SHAS.junk, SHAS.plain]
+    );
+    assert.deepEqual(
+      commits.map((c) => c.taskId),
+      [4, 1, 4, null, null]
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1.2 changedFilesForCommits (live repo)
+// ---------------------------------------------------------------------------
+
+describe('changedFilesForCommits', () => {
+  it('returns the sorted deduped union of files touched by the commits', () => {
+    const files = changedFilesForCommits(REPO, [SHAS.ownA, SHAS.ownB]);
+    assert.deepEqual(files, ['own-a.txt', 'own-b.txt']);
+  });
+
+  it('returns an empty array for an empty sha list', () => {
+    assert.deepEqual(changedFilesForCommits(REPO, []), []);
+  });
+
+  it('merge commits contribute nothing', () => {
+    // Build a side branch and merge it; the merge commit itself must not add
+    // files to the union (diff-tree --no-commit-id -r on a merge is empty).
+    git(['checkout', '-qb', 'side', baseSha]);
+    write('side.txt', 's\n');
+    const sideSha = commit('side work', '9');
+    git(['checkout', '-q', '-']);
+    git(['merge', '-q', '--no-ff', '-m', 'merge side', 'side']);
+    const mergeSha = git(['rev-parse', 'HEAD']);
+    assert.deepEqual(changedFilesForCommits(REPO, [mergeSha]), []);
+    // side commit alone still reports its file
+    assert.deepEqual(changedFilesForCommits(REPO, [sideSha]), ['side.txt']);
+    // Reset back so later range assertions are unaffected.
+    git(['reset', '-q', '--hard', SHAS.plain]);
+    git(['branch', '-qD', 'side']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 1.2 resolveAttribution (live repo + fail-open)
+// ---------------------------------------------------------------------------
+
+describe('resolveAttribution', () => {
+  it('resolves a trailer range to this task attributed files only', () => {
+    const res = resolveAttribution({
+      repoDir: REPO,
+      baseRef: baseSha,
+      headRef: 'HEAD',
+      taskNum: 4,
+    });
+    assert.equal(res.supported, true);
+    assert.equal(res.mode, 'trailer');
+    assert.equal(res.taskId, 4);
+    assert.deepEqual(res.foreignTasks, ['1']);
+    assert.equal(res.unattributedCount, 2);
+    assert.deepEqual(res.attributedFiles, ['own-a.txt', 'own-b.txt']);
+  });
+
+  it('falls back to mode none for an empty range', () => {
+    const empty = resolveAttribution({
+      repoDir: REPO,
+      baseRef: baseSha,
+      headRef: baseSha,
+      taskNum: 4,
+    });
+    assert.equal(empty.supported, true);
+    assert.equal(empty.mode, 'none');
+    assert.deepEqual(empty.foreignTasks, []);
+    assert.equal(empty.unattributedCount, 0);
+    assert.deepEqual(empty.attributedFiles, []);
+  });
+
+  it('resolves a single-own-commit range in trailer mode', () => {
+    const res = resolveAttribution({
+      repoDir: REPO,
+      baseRef: baseSha,
+      headRef: SHAS.ownA,
+      taskNum: 4,
+    });
+    assert.equal(res.mode, 'trailer');
+    assert.deepEqual(res.attributedFiles, ['own-a.txt']);
+  });
+
+  it('reports mode none when every commit is unattributed', () => {
+    const res = resolveAttribution({
+      repoDir: REPO,
+      baseRef: SHAS.junk,
+      headRef: SHAS.plain,
+      taskNum: 4,
+    });
+    assert.equal(res.supported, true);
+    assert.equal(res.mode, 'none');
+    assert.equal(res.unattributedCount, 1);
+    assert.deepEqual(res.attributedFiles, []);
+  });
+
+  it('never throws: bogus repoDir degrades to supported false', () => {
+    const res = resolveAttribution({
+      repoDir: path.join(ROOT, 'does-not-exist'),
+      baseRef: 'main',
+      headRef: 'HEAD',
+      taskNum: 4,
+    });
+    assert.deepEqual(res, {
+      supported: false,
+      mode: 'none',
+      taskId: null,
+      foreignTasks: [],
+      unattributedCount: 0,
+      attributedFiles: [],
+    });
+  });
+
+  it('never throws: unresolvable ref degrades to supported false', () => {
+    const res = resolveAttribution({
+      repoDir: REPO,
+      baseRef: 'no-such-ref',
+      headRef: 'HEAD',
+      taskNum: 4,
+    });
+    assert.equal(res.supported, false);
+    assert.equal(res.mode, 'none');
+  });
+});

--- a/plugins/work/scripts/workflows/task-verify/collect/attribution.js
+++ b/plugins/work/scripts/workflows/task-verify/collect/attribution.js
@@ -1,0 +1,194 @@
+'use strict';
+
+/**
+ * task-verify/collect/attribution.js — commit-attribution collector (GH-769).
+ *
+ * Parses `Work-Task` commit trailers, partitions a base..head range into
+ * own / foreign / unattributed commits for a given task number, and computes
+ * the attributed diff union for the own-commit set.
+ *
+ * Fail-open contract: `resolveAttribution` NEVER throws. Any git failure
+ * degrades to `{ supported: false, mode: 'none', ... }` so a boundary is
+ * never hard-blocked because of attribution (spec R3). All git reads go
+ * through the shared `git-facts.js git()` wrapper (array args, timeout
+ * bounded — no shell interpolation of trailer values or refs, spec R2).
+ */
+
+const { git } = require('./git-facts');
+
+/** Trailer key every wave commit carries: `Work-Task: <N>`. */
+const WORK_TASK_TRAILER = 'Work-Task';
+
+// Spec R2 hardening: only `4`, `task4`, `task 4` (any case, <= 4 digits).
+const WORK_TASK_VALUE_RE = /^(?:task\s*)?(\d{1,4})$/i;
+
+// git log field separators: %x1f between sha and trailer values, %x2c
+// between multiple trailer values on one commit.
+const LOG_FORMAT = `%H%x1f%(trailers:key=${WORK_TASK_TRAILER},valueonly,separator=%x2c)`;
+
+/**
+ * Parse a raw `Work-Task` trailer value into an integer task id.
+ * Anything outside `/^(?:task\s*)?(\d{1,4})$/i` is unattributed (null) —
+ * hostile values never crash parsing and never reach downstream as raw text.
+ *
+ * @param {unknown} raw trailer value as written in the commit
+ * @returns {number|null} re-serialized integer task id, or null
+ */
+function parseWorkTaskValue(raw) {
+  if (typeof raw !== 'string') return null;
+  const m = raw.trim().match(WORK_TASK_VALUE_RE);
+  return m ? Number.parseInt(m[1], 10) : null;
+}
+
+/**
+ * First valid task id among a commit's (possibly multiple) trailer values.
+ *
+ * @param {string} joined comma-joined `Work-Task` trailer values (may be '')
+ * @returns {number|null}
+ */
+function firstValidTaskId(joined) {
+  if (!joined) return null;
+  for (const value of joined.split(',')) {
+    const id = parseWorkTaskValue(value);
+    if (id !== null) return id;
+  }
+  return null;
+}
+
+/**
+ * List commits in `baseRef..headRef` (oldest first) with their attributed
+ * task id. Throws on git failure — callers that must not throw go through
+ * `resolveAttribution`.
+ *
+ * @param {string} repoDir
+ * @param {string} baseRef
+ * @param {string} headRef
+ * @returns {Array<{ sha: string, taskId: number|null }>}
+ */
+function commitsInRange(repoDir, baseRef, headRef) {
+  const out = git(repoDir, [
+    'log',
+    '--reverse',
+    `--format=${LOG_FORMAT}`,
+    `${baseRef}..${headRef}`,
+  ]);
+  if (!out) return [];
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const [sha, trailers = ''] = line.split('\x1f');
+      return { sha, taskId: firstValidTaskId(trailers) };
+    });
+}
+
+/**
+ * Partition commits into own / foreign / unattributed for `taskNum`.
+ * Own shas keep range order; foreign task ids are deduped, numerically
+ * sorted, and re-serialized as decimal strings (spec R2).
+ *
+ * @param {Array<{ sha: string, taskId: number|null }>} commits
+ * @param {number} taskNum
+ * @returns {{ own: string[], foreignTasks: string[], unattributedCount: number }}
+ */
+function partitionForTask(commits, taskNum) {
+  const own = [];
+  const foreign = new Set();
+  let unattributedCount = 0;
+  for (const { sha, taskId } of commits) {
+    if (taskId === null) unattributedCount += 1;
+    else if (taskId === taskNum) own.push(sha);
+    else foreign.add(taskId);
+  }
+  const foreignTasks = [...foreign].sort((a, b) => a - b).map((id) => String(id));
+  return { own, foreignTasks, unattributedCount };
+}
+
+/**
+ * Sorted, deduped union of files touched by `shas`. Merge commits contribute
+ * nothing (`git diff-tree --no-commit-id --name-only -r` on a merge without
+ * `-m` prints no paths). Throws on git failure — see `resolveAttribution`
+ * for the fail-open wrapper.
+ *
+ * @param {string} repoDir
+ * @param {string[]} shas
+ * @returns {string[]}
+ */
+function changedFilesForCommits(repoDir, shas) {
+  const files = new Set();
+  for (const sha of shas) {
+    const out = git(repoDir, ['diff-tree', '--no-commit-id', '--name-only', '-r', sha]);
+    if (!out) continue;
+    for (const f of out.split('\n')) {
+      if (f) files.add(f);
+    }
+  }
+  return [...files].sort();
+}
+
+/** The fail-open degraded result: attribution unavailable, never blocking. */
+function unsupportedResult() {
+  return {
+    supported: false,
+    mode: 'none',
+    taskId: null,
+    foreignTasks: [],
+    unattributedCount: 0,
+    attributedFiles: [],
+  };
+}
+
+/**
+ * Resolve attribution for a task over `baseRef..headRef`.
+ *
+ * - Trailer-attributed range → `{ supported: true, mode: 'trailer', taskId,
+ *   foreignTasks, unattributedCount, attributedFiles }` where
+ *   `attributedFiles` is the diff union of THIS task's commits only.
+ * - Range with no valid trailer at all → `mode: 'none'` (legacy diff keeps
+ *   authority downstream, spec R9).
+ * - ANY git failure (bogus repoDir, unresolvable ref, timeout) → the
+ *   `{ supported: false, mode: 'none', ... }` degraded shape. Never throws.
+ *
+ * @param {{ repoDir: string, baseRef: string, headRef: string, taskNum: number }} input
+ * @returns {{ supported: boolean, mode: 'trailer'|'none', taskId: number|null,
+ *   foreignTasks: string[], unattributedCount: number, attributedFiles: string[] }}
+ */
+function resolveAttribution({ repoDir, baseRef, headRef, taskNum }) {
+  try {
+    // Coerce to an integer so callers may pass a numeric string (task ids
+    // arrive as strings from the task parser); partitioning compares ints.
+    const taskId = Number.parseInt(taskNum, 10);
+    const commits = commitsInRange(repoDir, baseRef, headRef);
+    const { own, foreignTasks, unattributedCount } = partitionForTask(commits, taskId);
+    const anyAttributed = commits.some((c) => c.taskId !== null);
+    if (!anyAttributed) {
+      return {
+        supported: true,
+        mode: 'none',
+        taskId: null,
+        foreignTasks: [],
+        unattributedCount,
+        attributedFiles: [],
+      };
+    }
+    return {
+      supported: true,
+      mode: 'trailer',
+      taskId,
+      foreignTasks,
+      unattributedCount,
+      attributedFiles: changedFilesForCommits(repoDir, own),
+    };
+  } catch {
+    return unsupportedResult();
+  }
+}
+
+module.exports = {
+  WORK_TASK_TRAILER,
+  parseWorkTaskValue,
+  commitsInRange,
+  partitionForTask,
+  changedFilesForCommits,
+  resolveAttribution,
+};

--- a/plugins/work/scripts/workflows/task-verify/observe.js
+++ b/plugins/work/scripts/workflows/task-verify/observe.js
@@ -88,12 +88,18 @@ function resolveDiffWithAttribution({ repoDir, baseRef, headRef, scopeGlobs, tas
   if (attribution.supported && attribution.mode === 'trailer') {
     return { diff: diffFromFiles(attribution.attributedFiles, scope), attribution };
   }
-  // Rules 1 (mode 'none') and 3 (supported:false) — legacy diff kept. When the
-  // collector itself could not resolve (supported:false, e.g. an unresolvable
-  // base ref), the legacy read is fail-open so a task is never hard-blocked by
-  // a broken attribution read (spec R3/R9). The serial path (taskNum omitted,
-  // buildDiff) keeps its throw-on-failure semantics unchanged.
-  const legacy = attribution.supported ? changedFiles(repoDir, baseRef, headRef) : [];
+  // Rules 1 (mode 'none') and 3 (supported:false) — legacy diff kept. BOTH cases
+  // use the legacy base..HEAD read: on supported:false the refs are usually still
+  // valid (only the attribution collector failed), so we attempt the legacy diff
+  // and fall back to [] ONLY if that read ALSO throws — a task is never
+  // hard-blocked by a broken attribution read (spec R3/R9). The serial path
+  // (taskNum omitted, buildDiff) keeps its throw-on-failure semantics unchanged.
+  let legacy;
+  try {
+    legacy = changedFiles(repoDir, baseRef, headRef);
+  } catch {
+    legacy = [];
+  }
   return { diff: diffFromFiles(legacy, scope), attribution };
 }
 

--- a/plugins/work/scripts/workflows/task-verify/observe.js
+++ b/plugins/work/scripts/workflows/task-verify/observe.js
@@ -24,6 +24,7 @@ const { fileMatchesScope, TEST_FILE_EXT_RE } = require(
 const { changedFiles, fileExistsAtRef, resolveRef } = require('./collect/git-facts');
 const { ensureBaseWorktree, overlayFiles } = require('./collect/base-worktree');
 const { detectRunner, runDerivedTests } = require('./collect/runner');
+const { resolveAttribution } = require('./collect/attribution');
 const { profileFor } = require('./kind-profiles');
 
 const NEW_MARKER_RE = /\s*\((?:NEW|new)\)\s*$/;
@@ -44,9 +45,8 @@ function deriveTestFiles(files) {
   return files.filter((f) => TEST_FILE_EXT_RE.test(f));
 }
 
-function buildDiff({ repoDir, baseRef, headRef, scopeGlobs }) {
-  const files = changedFiles(repoDir, baseRef, headRef);
-  const scope = normalizeScope(scopeGlobs);
+/** Assemble the diff observation from an already-resolved file list. */
+function diffFromFiles(files, scope) {
   const scopeUnresolved = scope.length === 0;
   return {
     empty: files.length === 0,
@@ -55,6 +55,46 @@ function buildDiff({ repoDir, baseRef, headRef, scopeGlobs }) {
     outOfScope: scopeUnresolved ? [] : files.filter((f) => !fileMatchesScope(f, scope)),
     ...(scopeUnresolved ? { scopeUnresolved: true } : {}),
   };
+}
+
+function buildDiff({ repoDir, baseRef, headRef, scopeGlobs }) {
+  const files = changedFiles(repoDir, baseRef, headRef);
+  return diffFromFiles(files, normalizeScope(scopeGlobs));
+}
+
+/**
+ * Resolve the diff for a task, applying attribution when `taskNum` is given.
+ *
+ * Three rules (spec R8/R9), fail-open throughout:
+ *   1. No `Work-Task` trailer anywhere in range (mode 'none') → the legacy
+ *      `base..HEAD` diff, unchanged.
+ *   2. Foreign-attributed commits present (mode 'trailer') → `filesChanged`
+ *      is the union of THIS task's attributed commits ONLY; scope/out-of-scope
+ *      recomputed over that set.
+ *   3. Collector `supported: false` → legacy diff (never a hard block).
+ *
+ * Serial callers (no `taskNum`) get the legacy diff and NO `attribution` key,
+ * byte-for-byte identical to pre-GH-769 behavior.
+ *
+ * @returns {{ diff: object, attribution: object|null }}
+ */
+function resolveDiffWithAttribution({ repoDir, baseRef, headRef, scopeGlobs, taskNum }) {
+  const scope = normalizeScope(scopeGlobs);
+  if (taskNum === undefined || taskNum === null) {
+    return { diff: buildDiff({ repoDir, baseRef, headRef, scopeGlobs }), attribution: null };
+  }
+  const attribution = resolveAttribution({ repoDir, baseRef, headRef, taskNum });
+  // Rule 2 — attributed range with foreign commits: THIS task's files only.
+  if (attribution.supported && attribution.mode === 'trailer') {
+    return { diff: diffFromFiles(attribution.attributedFiles, scope), attribution };
+  }
+  // Rules 1 (mode 'none') and 3 (supported:false) — legacy diff kept. When the
+  // collector itself could not resolve (supported:false, e.g. an unresolvable
+  // base ref), the legacy read is fail-open so a task is never hard-blocked by
+  // a broken attribution read (spec R3/R9). The serial path (taskNum omitted,
+  // buildDiff) keeps its throw-on-failure semantics unchanged.
+  const legacy = attribution.supported ? changedFiles(repoDir, baseRef, headRef) : [];
+  return { diff: diffFromFiles(legacy, scope), attribution };
 }
 
 function buildDeliverables({ repoDir, headRef, scope }) {
@@ -128,18 +168,28 @@ function buildBaseRun({
  * @param {string[]} input.scopeGlobs - the task's Files-in-scope entries
  *   (from the canonical task parser); empty/null → scopeUnresolved.
  * @param {string} input.taskKind - planner kind.
+ * @param {number} [input.taskNum] - the task number (GH-769); when provided,
+ *   the diff is resolved from THIS task's attributed commits and an additive
+ *   `attribution` observation is emitted. Omitted → legacy `base..HEAD` diff,
+ *   no `attribution` key (serial backward compatibility).
  * @param {string} input.baseWorktreeDir - where the per-ticket base worktree lives.
  * @param {number} [input.timeoutMs]
  * @returns observations in the replay-corpus shape.
  */
 function buildObservations(input) {
-  const { repoDir, baseRef, scopeGlobs, taskKind, baseWorktreeDir, timeoutMs } = input;
+  const { repoDir, baseRef, scopeGlobs, taskKind, taskNum, baseWorktreeDir, timeoutMs } = input;
   // Resolve head to a SHA once: symbolic refs like 'HEAD' would re-resolve
   // against the BASE worktree's own HEAD during the overlay checkout.
   const headRef = resolveRef(repoDir, input.headRef || 'HEAD') || input.headRef || 'HEAD';
   const profile = profileFor(taskKind);
 
-  const diff = buildDiff({ repoDir, baseRef, headRef, scopeGlobs });
+  const { diff, attribution } = resolveDiffWithAttribution({
+    repoDir,
+    baseRef,
+    headRef,
+    scopeGlobs,
+    taskNum,
+  });
   const deliverables = buildDeliverables({ repoDir, headRef, scope: diff.scopeGlobs });
   const testFiles = deriveTestFiles(diff.filesChanged);
   const runner = detectRunner(repoDir);
@@ -163,6 +213,8 @@ function buildObservations(input) {
     headRun,
     coverage: { supported: false, changedLineCoveragePct: null },
     derivedTests: { files: testFiles, runner: runner || 'none' },
+    // Additive (GH-769): only present when a taskNum drove attribution.
+    ...(attribution ? { attribution } : {}),
   };
 }
 

--- a/plugins/work/scripts/workflows/task-verify/outcome-gate.js
+++ b/plugins/work/scripts/workflows/task-verify/outcome-gate.js
@@ -99,6 +99,10 @@ function runOutcomeGate(input, deps = {}) {
       exit: result.exit,
       reasons: result.reasons.slice(0, 5),
       derivedTests: observations.derivedTests,
+      // GH-769: additive attribution block (both task ids), present only when
+      // the observer produced one — mirrors shadow.js. The cross-task flag
+      // itself flows through recordOutcomeFlags unchanged.
+      ...(observations.attribution ? { attribution: observations.attribution } : {}),
     },
   });
 

--- a/plugins/work/scripts/workflows/task-verify/shadow.js
+++ b/plugins/work/scripts/workflows/task-verify/shadow.js
@@ -81,6 +81,10 @@ function runShadowVerification(input, deps = {}) {
       reasons: result.reasons.slice(0, 5),
       divergence: computeDivergence(incumbent, result.verdict),
       derivedTests: observations.derivedTests,
+      // GH-769: surface the attribution block (both task ids) only when the
+      // observer produced one, so a cross-task-attribution flag is triageable
+      // from .work-actions.json. Serial observations stay byte-identical.
+      ...(observations.attribution ? { attribution: observations.attribution } : {}),
     },
   });
   return result;

--- a/plugins/work/scripts/workflows/task-verify/verdict-engine.js
+++ b/plugins/work/scripts/workflows/task-verify/verdict-engine.js
@@ -180,7 +180,8 @@ function collectAttributionFlags(ctx) {
   if (foreignTasks.length === 0) return;
   ctx.flags.add(FLAG_KINDS.crossTaskAttribution);
   const found = foreignTasks.map((t) => Number.parseInt(t, 10)).join(', ');
-  const expected = Number.parseInt(attribution.taskId, 10);
+  const expected =
+    attribution.taskId !== null ? Number.parseInt(attribution.taskId, 10) : '(unknown)';
   ctx.reasons.push(
     `attribution: range contains commits attributed to task(s) ${found} (expected task ${expected})`
   );

--- a/plugins/work/scripts/workflows/task-verify/verdict-engine.js
+++ b/plugins/work/scripts/workflows/task-verify/verdict-engine.js
@@ -167,6 +167,26 @@ function collectRunnerFlags(ctx) {
 }
 
 /**
+ * Cross-task attribution flag (GH-769): a range containing commits attributed
+ * to OTHER tasks is a mechanism failure — flag for task_review, never a
+ * contradiction, never a typed exit (mechanism failures degrade to flags,
+ * per the design rules above). Task ids in the reason are re-serialized
+ * integers, never raw commit text (GH-769 trailer hardening).
+ */
+function collectAttributionFlags(ctx) {
+  const attribution = ctx.attribution;
+  if (!attribution || attribution.supported !== true) return;
+  const foreignTasks = attribution.foreignTasks || [];
+  if (foreignTasks.length === 0) return;
+  ctx.flags.add(FLAG_KINDS.crossTaskAttribution);
+  const found = foreignTasks.map((t) => Number.parseInt(t, 10)).join(', ');
+  const expected = Number.parseInt(attribution.taskId, 10);
+  ctx.reasons.push(
+    `attribution: range contains commits attributed to task(s) ${found} (expected task ${expected})`
+  );
+}
+
+/**
  * Evaluate one task boundary.
  *
  * @param {object} observations - replay-corpus observation shape
@@ -185,6 +205,7 @@ function makeContext(observations, taskKind, options) {
     baseRun: obs.baseRun || {},
     headRun: obs.headRun || {},
     coverage: obs.coverage || {},
+    attribution: obs.attribution || null,
     profile,
     applicable: new Set(profile.invariants),
     options,
@@ -229,6 +250,7 @@ function evaluate(observations, taskKind, options = {}) {
   evaluatePassOnHead(ctx);
   evaluateCoverage(ctx);
   collectRunnerFlags(ctx);
+  collectAttributionFlags(ctx);
   return buildResult(ctx);
 }
 

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/implement.test.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/implement.test.js
@@ -1,0 +1,164 @@
+/**
+ * Wave-attribution dispatch tests (GH-769 Task 14).
+ *
+ * buildParallelOverride appends a per-delegate `Work-Task: <N>` trailer
+ * instruction bound to each delegate's own task number; the single-task
+ * (serial) dispatch path carries no attribution block. The trailer key in the
+ * instruction is the exact `WORK_TASK_TRAILER` constant from attribution.js so
+ * instruction text and the boundary parser can never drift.
+ *
+ * Run: node --test scripts/workflows/work/lib/step-enrichments/__tests__/implement.test.js
+ */
+
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { resetRuntimeCache } = require('../../../../lib/runtime');
+const registerImplement = require('../implement');
+const { WORK_TASK_TRAILER } = require('../../../../task-verify/collect/attribution');
+
+const ENV_KEYS = ['AGENT_RUNTIME', 'AGENT_RUNTIME_MODE', 'IMPLEMENT_AGENT', 'WORK_TDD_MODE'];
+const saved = {};
+let tmp;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.AGENT_RUNTIME = 'claude';
+  resetRuntimeCache();
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'implement-attr-'));
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  resetRuntimeCache();
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+const PARALLEL_TASKS_MD = [
+  '# Tasks',
+  '',
+  '## Task 1 — First thing',
+  '### Type',
+  'backend',
+  '### Parallel',
+  'Yes',
+  '### Dependencies',
+  'None',
+  '### Files in scope',
+  '- src/a.js',
+  '',
+  '## Task 2 — Second thing',
+  '### Type',
+  'backend',
+  '### Parallel',
+  'Yes',
+  '### Dependencies',
+  'None',
+  '### Files in scope',
+  '- src/b.js',
+  '',
+].join('\n');
+
+const SINGLE_TASK_MD = [
+  '# Tasks',
+  '',
+  '## Task 1 — Only thing',
+  '### Type',
+  'backend',
+  '### Dependencies',
+  'None',
+  '### Files in scope',
+  '- src/a.js',
+  '',
+].join('\n');
+
+function handlers() {
+  const h = {};
+  registerImplement((step, fn) => {
+    h[step] = fn;
+  });
+  return h;
+}
+
+function runParallel() {
+  fs.writeFileSync(path.join(tmp, 'tasks.md'), PARALLEL_TASKS_MD);
+  const entry = {
+    step: 'implement',
+    agentType: 'general-purpose',
+    agentPrompt: '## Current Task: Task 1 — First thing\n\nTask 1 of 2\n',
+  };
+  handlers().implement(entry, { ticket: 'GH-9', tasksDir: tmp });
+  return entry._overrideInstruction;
+}
+
+function runSingle() {
+  fs.writeFileSync(path.join(tmp, 'tasks.md'), SINGLE_TASK_MD);
+  const entry = {
+    step: 'implement',
+    agentType: 'general-purpose',
+    agentPrompt: '## Current Task: Task 1 — Only thing\n',
+  };
+  handlers().implement(entry, { ticket: 'GH-9', tasksDir: tmp });
+  return entry;
+}
+
+describe('wave attribution dispatch (GH-769)', () => {
+  it('each delegate prompt carries its own Work-Task trailer instruction', () => {
+    const instr = runParallel();
+    assert.ok(instr, 'parallel path produced an override instruction');
+    assert.equal(instr.delegates.length, 2);
+    const prompts = Object.fromEntries(
+      instr.delegates.map((d) => {
+        const numMatch = d.description.match(/Task (\d+)\//);
+        return [numMatch[1], d.prompt];
+      })
+    );
+    assert.match(prompts['1'], /### Commit attribution \(parallel wave\)/);
+    assert.match(prompts['1'], /git commit --trailer "Work-Task: 1"/);
+    assert.match(prompts['2'], /git commit --trailer "Work-Task: 2"/);
+    // Each delegate's instruction is bound to ITS OWN task number.
+    assert.ok(!prompts['1'].includes('Work-Task: 2'));
+    assert.ok(!prompts['2'].includes('Work-Task: 1'));
+  });
+
+  it('the instruction warns of UNVERIFIED degradation', () => {
+    const instr = runParallel();
+    for (const d of instr.delegates) {
+      assert.match(d.prompt, /degrade to UNVERIFIED/);
+    }
+  });
+
+  it('the trailer key equals WORK_TASK_TRAILER from attribution.js (no drift)', () => {
+    const instr = runParallel();
+    for (const d of instr.delegates) {
+      assert.match(d.prompt, new RegExp(`${WORK_TASK_TRAILER}: \\d`));
+    }
+    assert.equal(WORK_TASK_TRAILER, 'Work-Task');
+  });
+
+  it('the single-task (serial) dispatch prompt carries NO attribution block', () => {
+    const entry = runSingle();
+    assert.equal(entry._overrideInstruction, undefined, 'no parallel override for a single task');
+    assert.ok(!/Commit attribution \(parallel wave\)/.test(entry.agentPrompt));
+    assert.ok(!/Work-Task/.test(entry.agentPrompt));
+  });
+
+  it('parallel outcome-mode delegates also carry the attribution block', () => {
+    process.env.WORK_TDD_MODE = 'outcome';
+    const instr = runParallel();
+    for (const d of instr.delegates) {
+      assert.match(d.prompt, /### Commit attribution \(parallel wave\)/);
+    }
+  });
+});

--- a/plugins/work/scripts/workflows/work/lib/step-enrichments/implement.js
+++ b/plugins/work/scripts/workflows/work/lib/step-enrichments/implement.js
@@ -22,6 +22,9 @@ const { findReadyTasks } = require(path.join(__dirname, '..', 'task-graph'));
 const { T, renderDelegateForRuntime, getRuntime } = require(
   path.join(__dirname, '..', '..', '..', 'lib', 'instruction-vocab')
 );
+const { WORK_TASK_TRAILER } = require(
+  path.join(__dirname, '..', '..', '..', 'task-verify', 'collect', 'attribution')
+);
 
 const TASK_NEXT_SCRIPT = path.resolve(
   __dirname,
@@ -173,6 +176,32 @@ function parseTaskHeader(agentPrompt) {
 }
 
 /**
+ * GH-769 wave attribution: every commit in a parallel wave shares one worktree
+ * and one branch, so the boundary observer partitions the range by a
+ * `Work-Task: <N>` commit trailer. Each wave delegate is instructed to stamp
+ * its own task number; a commit without the trailer cannot be attributed and
+ * degrades that boundary to UNVERIFIED. The trailer key is imported from
+ * attribution.js so instruction text and the parser can never drift. Serial
+ * (single-task) dispatch never appends this block.
+ *
+ * @param {number|string} taskNum the delegate's own task number
+ * @returns {string} the instruction block appended to the delegate prompt
+ */
+function waveAttributionInstruction(taskNum) {
+  return [
+    '',
+    '### Commit attribution (parallel wave)',
+    'Other tasks are committing into this same worktree concurrently. EVERY',
+    'commit you create MUST carry the trailer identifying this task:',
+    '```bash',
+    `git commit --trailer "${WORK_TASK_TRAILER}: ${taskNum}" -m "..."`,
+    '```',
+    `A commit without this \`${WORK_TASK_TRAILER}: ${taskNum}\` trailer cannot be attributed to`,
+    'your task and your boundary will degrade to UNVERIFIED.',
+  ].join('\n');
+}
+
+/**
  * Parallel dispatch path: one delegate per ready-to-run task. Returns the
  * override instruction, or null when the plan has no parallel batch to run.
  */
@@ -187,16 +216,23 @@ function buildParallelOverride(ticket, tasksDir, currentTaskNum, totalTasks) {
   const allTasks = parseFullTasks(tasksDir) || [];
 
   const rt = getRuntime();
+  const outcomeMode = process.env.WORK_TDD_MODE === 'outcome';
   const delegates = parallelTasks.map((num) => {
     const task = allTasks.find((t) => t.num === num);
     const title = task?.title || 'Implementation';
     const agentType = resolveAgentType(tasksDir, num);
+    const basePrompt = outcomeMode
+      ? buildOutcomePrompt(ticket, num, totalTasks, title, tasksDir)
+      : buildSelfPacedPrompt(ticket, num, totalTasks, title);
+    // GH-769: every wave delegate stamps its own Work-Task trailer so the
+    // boundary observer resolves its diff from its own commits.
+    const prompt = basePrompt + waveAttributionInstruction(num);
     return renderDelegateForRuntime(
       {
         type: 'task',
         agentType,
         description: `Task ${num}/${totalTasks} — ${title}`,
-        prompt: buildSelfPacedPrompt(ticket, num, totalTasks, title),
+        prompt,
         note: T('delegate.task.note.short', {}, rt.name),
       },
       rt


### PR DESCRIPTION
## Existing Behavior

- The boundary observer computes the task diff as the full `base..HEAD` range, regardless of how many tasks share a worktree and branch during a parallel implement wave.
- No commit-level attribution exists: if multiple tasks commit interleaved into one branch, each task's `buildObservations` sees the combined file set, which can produce false scope violations or empty diffs.
- The `FLAG_KINDS` vocabulary has no entry for cross-task attribution anomalies; verdict-engine has no collector for this class of mechanism failure.
- `implement.js` emits parallel wave delegates without any instruction to stamp commits with a per-task identifier.

## Intended New Behavior

- Each wave delegate is instructed to stamp every commit with a `Work-Task: <N>` trailer (`waveAttributionInstruction` in `implement.js`), keyed to the exact `WORK_TASK_TRAILER` constant imported from `attribution.js` so the instruction and parser can never drift.
- `task-verify/collect/attribution.js` parses the `base..HEAD` commit range by trailer, partitions commits into own/foreign/unattributed sets, and resolves the diff union from THIS task's commits only — fail-open throughout (any git error degrades to `supported: false`, never a hard block).
- `observe.js` (`resolveDiffWithAttribution`) applies attribution when `taskNum` is present: mode `trailer` → attributed file set; mode `none` or `supported: false` → legacy `base..HEAD` diff. Serial callers (no `taskNum`) are byte-identical to pre-GH-769 behavior.
- `verdict-engine.js` adds `collectAttributionFlags`: a range containing foreign-attributed commits emits `FLAG_KINDS.crossTaskAttribution` and a reason naming the sibling task ids — never a contradiction, never a typed exit, always a flag-only mechanism-failure degrading to UNVERIFIED.
- `shadow.js` and `outcome-gate.js` surface the `attribution` block in `.work-actions.json` audit meta so the cross-task flag is triageable by operators.
- `replay-corpus` gains `validateAttribution` (validates the optional `observations.attribution` block in fixtures) and a 23rd fixture (`gh-720-cross-attributed-commits-resolve-cleanly.json`) covering the clean-own-diff + cross-task-attribution-flag scenario.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [ ] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Unit / integration (backend — no UI changes):**

1. Run the attribution unit tests directly:
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/task-verify/collect/__tests__/attribution.test.js
   ```
   Expected: all subtests pass (trailer parse, partition, changedFilesForCommits, resolveAttribution — including fail-open on bad refs).

2. Run the two-task interleaved-wave integration test:
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/task-verify/__tests__/attribution-live.test.js
   ```
   Expected: live temp-repo test creates interleaved commits (order 1,2,1,2), drives `buildObservations` + `observeBoundary` + `evaluate`, and asserts each task's resolved diff is disjoint, `foreignTasks` names the sibling, and `evaluate` returns `UNVERIFIED` with `['cross-task-attribution']`.

3. Run the verdict-engine tests to verify `collectAttributionFlags`:
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/task-verify/__tests__/verdict-engine.test.js
   ```

4. Run the implement wave-attribution dispatch tests:
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/work/lib/step-enrichments/__tests__/implement.test.js
   ```
   Expected: parallel delegates each carry a `Work-Task: <N>` trailer instruction bound to their own task number; single-task dispatch has no attribution block.

5. Verify serial (no-`taskNum`) path is unchanged by running the existing boundary/observe/outcome-gate/shadow tests:
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/task-verify/__tests__/boundary.test.js plugins/work/scripts/workflows/task-verify/__tests__/observe.test.js plugins/work/scripts/workflows/task-verify/__tests__/outcome-gate.test.js plugins/work/scripts/workflows/task-verify/__tests__/shadow.test.js
   ```

6. Confirm the replay corpus is still 100% green (includes the 23rd fixture):
   ```bash
   node --test --test-concurrency=1 plugins/work/scripts/workflows/lib/replay-corpus/__tests__/index.test.js
   ```

Closes #769
