### PR TITLE
feat(hooks): once-per-session reminder dispatcher + ledger (GH-773)

### DIFF
--- a/plugins/work/docs/hooks.md
+++ b/plugins/work/docs/hooks.md
@@ -304,3 +304,101 @@ codex exec resume <SESSION_ID> --json --dangerously-bypass-hook-trust \
   invoking directory, not globally) — run it from the agent's worktree or pass the id.
 - `exec resume` REJECTS `-s`/`-C` (narrower flag surface than `exec`) — set the sandbox via
   `-c sandbox_mode=…`; `--json`/`-o`/`--skip-git-repo-check`/both bypass flags are accepted.
+
+## Reminder dispatcher & manifest
+
+`UserPromptSubmit` reminder hooks historically fired on **every** prompt, each in
+its own process, re-injecting identical static guidance every turn — N reminders
+meant N processes and N context re-injections. GH-773 replaces that pattern with
+a single consolidated dispatcher plus a session-scoped ledger primitive.
+
+- **`remind-once.js`** — the generic session-scoped ledger. Keyed by **session id
+  (file) + reminder id (entry)**, never by cwd (the GH-583 anti-pattern). Two
+  sessions in the same folder stay distinct; the same session across two prompts
+  dedupes. The session id comes from the hook payload
+  (`normalizeHookPayload(payload).sessionId` — `session_id` first, then
+  `CLAUDE_CODE_SESSION_ID`, which Claude Code rotates on `/clear` and per new
+  conversation, re-arming all once-per-session reminders). Ledger store:
+  `work-workflow/.reminders/<sessionId>.json` under the user cache dir (override
+  with `REMIND_ONCE_SESSION_DIR`). It stores reminder ids + counters +
+  timestamps ONLY — no prompt text, no bodies.
+- **`reminder-dispatcher.js`** — ONE `UserPromptSubmit` hook (one process per
+  prompt regardless of manifest size). It reads a manifest, validates entries,
+  filters by trigger + cadence, and emits ONE combined context block via
+  `getRuntime(payload).emit.context('UserPromptSubmit', block)`. Fail-open: any
+  error → emit nothing, exit 0, never block the prompt.
+
+### Manifest format
+
+`reminders.manifest.json` is a JSON array of entries. The path resolves from the
+`REMINDER_MANIFEST` env var, else the shipped default
+`plugins/work/scripts/workflows/lib/hooks/reminders.manifest.json`.
+
+| Field     | Type                              | Required | Notes |
+|-----------|-----------------------------------|----------|-------|
+| `id`      | string                            | yes      | Unique reminder id; the ledger key. |
+| `trigger` | `"always"` or a regex string      | yes      | Regex is tested against the prompt text; `"always"` fires unconditionally. A bad regex drops only that entry. |
+| `body`    | path (relative to the manifest)   | yes      | File whose contents are injected. Must stay within the manifest's directory tree (path-traversal rejected). Missing file drops only that entry. |
+| `cadence` | `"once-per-session"` \| `"every-prompt"` | no  | **Defaults to `once-per-session`.** Unknown values drop only that entry. |
+
+**Cadence contract:** `once-per-session` (the default for static guidance) fires
+exactly once per session and re-arms after `/clear` or a new session.
+`every-prompt` is reserved for genuinely dynamic checks (branch name, live
+machine state) that must re-evaluate each turn.
+
+Example (the shipped default):
+
+```json
+[
+  {
+    "id": "agent-picker",
+    "trigger": "always",
+    "body": "reminders/agent-picker.reminder.md",
+    "cadence": "once-per-session"
+  }
+]
+```
+
+Validate a manifest in CI: `node reminder-dispatcher.js validate <manifest>`
+exits 0 when clean, exits 1 with per-entry diagnostics.
+
+### Migrating a standalone `prompt-reminder.sh`-style hook
+
+A personal reminder hook that shells out every prompt to echo the same static
+text — e.g. a "which of the 4 agents do I use" crib sheet — becomes a single
+manifest entry:
+
+1. Move the static text into a body file, e.g.
+   `reminders/agent-picker.reminder.md`.
+2. Add one manifest entry pointing at it:
+
+   ```json
+   {
+     "id": "agent-picker",
+     "trigger": "always",
+     "body": "reminders/agent-picker.reminder.md",
+     "cadence": "once-per-session"
+   }
+   ```
+
+3. Delete the standalone `UserPromptSubmit` hook. The dispatcher now injects the
+   guidance once per session instead of on every prompt, and consolidates it with
+   any other manifest entries into a single process + single context block.
+
+Use `every-prompt` instead of `once-per-session` only when the body genuinely
+changes turn-to-turn (dynamic state); otherwise keep the default so the cost
+amortizes to once per session.
+
+### Migration audit (in-repo)
+
+An audit of every plugin's `UserPromptSubmit` entries found **zero purely-static
+in-repo reminders** to migrate: work is a matcher-gated `/work` router, synapsys
+is a dynamic memory injector (its own ledger), maestro reads live orchestration
+state, and heimdall has no `UserPromptSubmit` entry. The dispatcher therefore
+ships as a documented extension point + demonstrative manifest entry rather than
+replacing an existing static reminder.
+
+**Personal hooks under the user config dir are documentation targets only.** This
+ticket edits no user settings; the migration steps above describe how a user
+ports their own personal reminder hooks onto the manifest — the plugin never
+writes to the user's `settings.json`.

--- a/plugins/work/hooks/hooks.json
+++ b/plugins/work/hooks/hooks.json
@@ -10,6 +10,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/scripts/workflows/lib/hooks/reminder-dispatcher.js",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/hooks-json-dispatcher.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/hooks-json-dispatcher.test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+/**
+ * Guard test for the reminder-dispatcher registration in
+ * plugins/work/hooks/hooks.json. Asserts:
+ *   - hooks.json parses as valid JSON;
+ *   - exactly ONE UserPromptSubmit hook invokes reminder-dispatcher.js
+ *     (one process per prompt, regardless of manifest entry count);
+ *   - it uses direct `node ${CLAUDE_PLUGIN_ROOT}/...` invocation (no `sh -c`);
+ *   - the existing /work router entry (work-hook.js) is preserved.
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const HOOKS_JSON = path.resolve(__dirname, '..', '..', '..', '..', '..', 'hooks', 'hooks.json');
+
+function loadHooks() {
+  return JSON.parse(fs.readFileSync(HOOKS_JSON, 'utf8'));
+}
+
+function allUpsCommands(cfg) {
+  const groups = cfg.hooks.UserPromptSubmit || [];
+  return groups.flatMap((g) => (g.hooks || []).map((h) => h.command || ''));
+}
+
+describe('hooks.json reminder-dispatcher registration', () => {
+  it('parses as valid JSON', () => {
+    assert.doesNotThrow(loadHooks);
+  });
+
+  it('registers reminder-dispatcher.js exactly once under UserPromptSubmit', () => {
+    const cmds = allUpsCommands(loadHooks());
+    const hits = cmds.filter((c) => c.includes('reminder-dispatcher.js'));
+    assert.equal(hits.length, 1);
+  });
+
+  it('invokes the dispatcher via direct node, not sh -c', () => {
+    const cmd = allUpsCommands(loadHooks()).find((c) => c.includes('reminder-dispatcher.js'));
+    assert.ok(cmd);
+    assert.match(
+      cmd,
+      /node \$\{CLAUDE_PLUGIN_ROOT\}\/scripts\/workflows\/lib\/hooks\/reminder-dispatcher\.js/
+    );
+    assert.doesNotMatch(cmd, /sh\s+-c/);
+  });
+
+  it('preserves the /work router entry', () => {
+    const cfg = loadHooks();
+    const groups = cfg.hooks.UserPromptSubmit || [];
+    const router = groups.find((g) => g.matcher === '^\\s*/work\\s+');
+    assert.ok(router, 'router entry missing');
+    assert.ok((router.hooks || []).some((h) => (h.command || '').includes('work-hook.js')));
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/remind-once.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/remind-once.test.js
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * Tests for remind-once.js — the session-scoped reminder ledger primitive.
+ *
+ * Coverage:
+ *   1. resolveSessionId — payload-first via normalizeHookPayload; empty payload
+ *      → stable sha256 hash (never a raw cwd); unsafe ids hashed via SAFE_ID_RE.
+ *   2. shouldRemind — every-prompt always true; once-per-session true only
+ *      before a record and false after; ledger read error fails toward true.
+ *   3. recordReminder — writes { firedAt, count }; second call increments count.
+ *   4. Keying isolation — two session ids in the SAME folder → distinct files;
+ *      recording under one does not dedupe the other.
+ *   5. resetForSession re-arms; gcStaleLedgers removes stale files, keeps fresh.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const remindOnce = require('../remind-once');
+
+let tmp;
+let savedEnv;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'remind-once-'));
+  process.env.REMIND_ONCE_SESSION_DIR = tmp;
+  // Scrub the ambient session-id env legs so "empty payload" tests exercise
+  // the sha256(cwd+start) degradation, not the launching terminal's id.
+  savedEnv = {
+    CLAUDE_CODE_SESSION_ID: process.env.CLAUDE_CODE_SESSION_ID,
+    AGENT_SESSION_ID: process.env.AGENT_SESSION_ID,
+  };
+  delete process.env.CLAUDE_CODE_SESSION_ID;
+  delete process.env.AGENT_SESSION_ID;
+});
+
+afterEach(() => {
+  delete process.env.REMIND_ONCE_SESSION_DIR;
+  for (const [k, v] of Object.entries(savedEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+describe('resolveSessionId', () => {
+  it('resolves payload.session_id first', () => {
+    assert.equal(remindOnce.resolveSessionId({ session_id: 'sess-ABC_123' }), 'sess-ABC_123');
+  });
+
+  it('falls back to a stable sha256 hash (never raw cwd) on empty payload', () => {
+    const id = remindOnce.resolveSessionId({});
+    assert.match(id, /^[a-f0-9]{32}$/);
+    assert.notEqual(id, process.cwd());
+    // Stable within a process (same cwd + processStart).
+    assert.equal(id, remindOnce.resolveSessionId({}));
+  });
+
+  it('sanitizes unsafe session ids via SAFE_ID_RE (hashes path-traversal)', () => {
+    const id = remindOnce.resolveSessionId({ session_id: '../../etc/passwd' });
+    assert.match(id, /^[a-f0-9]{32}$/);
+    assert.ok(!id.includes('/'));
+  });
+});
+
+describe('shouldRemind cadence', () => {
+  it('every-prompt always returns true', () => {
+    assert.equal(remindOnce.shouldRemind('s1', 'r1', 'every-prompt'), true);
+    remindOnce.recordReminder('s1', 'r1');
+    assert.equal(remindOnce.shouldRemind('s1', 'r1', 'every-prompt'), true);
+  });
+
+  it('once-per-session true before a record, false after', () => {
+    assert.equal(remindOnce.shouldRemind('s2', 'r1', 'once-per-session'), true);
+    remindOnce.recordReminder('s2', 'r1');
+    assert.equal(remindOnce.shouldRemind('s2', 'r1', 'once-per-session'), false);
+  });
+
+  it('ledger read error fails toward true (never suppresses first fire)', () => {
+    // Point the dir at a path that cannot be read as a directory of files by
+    // writing a bogus (non-JSON) ledger; shouldRemind must still return true.
+    const file = path.join(tmp, 's3.json');
+    fs.writeFileSync(file, 'not-json{{{');
+    assert.equal(remindOnce.shouldRemind('s3', 'r1', 'once-per-session'), true);
+  });
+});
+
+describe('recordReminder ledger shape', () => {
+  it('writes { firedAt, count } and increments count on repeat', () => {
+    remindOnce.recordReminder('s4', 'agent-picker');
+    let raw = JSON.parse(fs.readFileSync(path.join(tmp, 's4.json'), 'utf8'));
+    assert.equal(raw.reminders['agent-picker'].count, 1);
+    assert.equal(typeof raw.reminders['agent-picker'].firedAt, 'string');
+    remindOnce.recordReminder('s4', 'agent-picker');
+    raw = JSON.parse(fs.readFileSync(path.join(tmp, 's4.json'), 'utf8'));
+    assert.equal(raw.reminders['agent-picker'].count, 2);
+  });
+
+  it('stores only reminder ids + counters + timestamps (no bodies/prompts)', () => {
+    remindOnce.recordReminder('s5', 'r1');
+    const raw = JSON.parse(fs.readFileSync(path.join(tmp, 's5.json'), 'utf8'));
+    const keys = Object.keys(raw.reminders.r1);
+    assert.deepEqual(keys.sort(), ['count', 'firedAt']);
+  });
+});
+
+describe('keying isolation (session id, never cwd)', () => {
+  it('two session ids in the same folder → distinct ledger files', () => {
+    remindOnce.recordReminder('sessA', 'r1');
+    assert.equal(remindOnce.shouldRemind('sessA', 'r1', 'once-per-session'), false);
+    // Different session, SAME working folder → not deduped.
+    assert.equal(remindOnce.shouldRemind('sessB', 'r1', 'once-per-session'), true);
+    assert.ok(fs.existsSync(path.join(tmp, 'sessA.json')));
+    assert.ok(!fs.existsSync(path.join(tmp, 'sessB.json')));
+  });
+});
+
+describe('resetForSession + gcStaleLedgers', () => {
+  it('resetForSession re-arms all once-per-session reminders', () => {
+    remindOnce.recordReminder('s6', 'r1');
+    assert.equal(remindOnce.shouldRemind('s6', 'r1', 'once-per-session'), false);
+    remindOnce.resetForSession('s6');
+    assert.equal(remindOnce.shouldRemind('s6', 'r1', 'once-per-session'), true);
+  });
+
+  it('gcStaleLedgers removes files older than maxAgeMs, keeps fresh', () => {
+    remindOnce.recordReminder('stale', 'r1');
+    remindOnce.recordReminder('fresh', 'r1');
+    const staleFile = path.join(tmp, 'stale.json');
+    const old = Date.now() - 10 * 24 * 60 * 60 * 1000;
+    fs.utimesSync(staleFile, old / 1000, old / 1000);
+    remindOnce.gcStaleLedgers({ maxAgeMs: 7 * 24 * 60 * 60 * 1000 });
+    assert.ok(!fs.existsSync(staleFile));
+    assert.ok(fs.existsSync(path.join(tmp, 'fresh.json')));
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/reminder-dispatcher.integration.test.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/reminder-dispatcher.integration.test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * Integration tests for reminder-dispatcher.js — the single consolidated
+ * UserPromptSubmit reminder hook. Spawns the hook as a child process (the
+ * established pattern for hook behavior) with a temp manifest, temp body
+ * files, and REMIND_ONCE_SESSION_DIR isolation.
+ *
+ * Coverage:
+ *   - validateManifest / `validate` CLI: bad regex, missing body, unknown
+ *     cadence each drop only the offending entry; clean manifest → exit 0.
+ *   - Cadence: once-per-session fires on prompt 1, suppressed on prompt 2 (same
+ *     session), re-armed by a new session id; every-prompt fires every prompt.
+ *   - Trigger regex gates a reminder to matching prompts; "always" always fires.
+ *   - N entries → ONE combined block from ONE process.
+ *   - Fail-open: empty/parse-error stdin, unreadable manifest → exit 0, no out.
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const HOOK = path.resolve(__dirname, '..', 'reminder-dispatcher.js');
+
+let tmp;
+let ledgerDir;
+let bodyDir;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reminder-disp-'));
+  ledgerDir = path.join(tmp, 'ledgers');
+  bodyDir = path.join(tmp, 'bodies');
+  fs.mkdirSync(ledgerDir, { recursive: true });
+  fs.mkdirSync(bodyDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function writeBody(name, text) {
+  const p = path.join(bodyDir, name);
+  fs.writeFileSync(p, text);
+  return p;
+}
+
+function writeManifest(entries) {
+  const p = path.join(tmp, 'reminders.manifest.json');
+  fs.writeFileSync(p, JSON.stringify(entries));
+  return p;
+}
+
+function run(args, { stdin, manifest, sessionId, env = {} } = {}) {
+  const childEnv = { ...process.env, REMIND_ONCE_SESSION_DIR: ledgerDir, ...env };
+  // Scrub inherited node --test flags so the child runs the hook, not tests.
+  delete childEnv.NODE_TEST_CONTEXT;
+  delete childEnv.NODE_OPTIONS;
+  delete childEnv.CLAUDE_CODE_SESSION_ID;
+  delete childEnv.AGENT_SESSION_ID;
+  if (manifest) childEnv.REMINDER_MANIFEST = manifest;
+  const input =
+    stdin === null || stdin === undefined
+      ? ''
+      : JSON.stringify({ session_id: sessionId, prompt: stdin.prompt });
+  const r = spawnSync(process.execPath, [HOOK, ...args], {
+    input,
+    encoding: 'utf8',
+    env: childEnv,
+  });
+  return { code: r.status, stdout: r.stdout || '', stderr: r.stderr || '' };
+}
+
+describe('validate CLI + manifest validation', () => {
+  it('exits 0 for a clean manifest', () => {
+    const body = writeBody('a.md', 'A');
+    const manifest = writeManifest([{ id: 'a', trigger: 'always', body }]);
+    const r = run(['validate', manifest]);
+    assert.equal(r.code, 0);
+  });
+
+  it('exits 1 and drops bad-regex / missing-body / unknown-cadence entries', () => {
+    const body = writeBody('a.md', 'A');
+    const manifest = writeManifest([
+      { id: 'ok', trigger: 'always', body },
+      { id: 'badre', trigger: '(', body },
+      { id: 'nobody', trigger: 'always', body: path.join(bodyDir, 'missing.md') },
+      { id: 'badcad', trigger: 'always', body, cadence: 'hourly' },
+    ]);
+    const r = run(['validate', manifest]);
+    assert.equal(r.code, 1);
+    assert.match(r.stderr + r.stdout, /badre/);
+    assert.match(r.stderr + r.stdout, /nobody/);
+    assert.match(r.stderr + r.stdout, /badcad/);
+  });
+});
+
+describe('cadence + trigger filtering (hook path)', () => {
+  it('once-per-session fires on prompt 1, suppressed on prompt 2, re-armed by new session', () => {
+    const body = writeBody('a.md', 'AGENT-BLOCK');
+    const manifest = writeManifest([
+      { id: 'a', trigger: 'always', body, cadence: 'once-per-session' },
+    ]);
+    const first = run([], { stdin: { prompt: 'hello' }, manifest, sessionId: 'sess1' });
+    assert.equal(first.code, 0);
+    assert.match(first.stdout, /AGENT-BLOCK/);
+    const second = run([], { stdin: { prompt: 'hello again' }, manifest, sessionId: 'sess1' });
+    assert.equal(second.code, 0);
+    assert.doesNotMatch(second.stdout, /AGENT-BLOCK/);
+    const other = run([], { stdin: { prompt: 'hi' }, manifest, sessionId: 'sess2' });
+    assert.match(other.stdout, /AGENT-BLOCK/);
+  });
+
+  it('every-prompt fires on every prompt', () => {
+    const body = writeBody('e.md', 'EVERY');
+    const manifest = writeManifest([{ id: 'e', trigger: 'always', body, cadence: 'every-prompt' }]);
+    const first = run([], { stdin: { prompt: 'x' }, manifest, sessionId: 's' });
+    const second = run([], { stdin: { prompt: 'y' }, manifest, sessionId: 's' });
+    assert.match(first.stdout, /EVERY/);
+    assert.match(second.stdout, /EVERY/);
+  });
+
+  it('trigger regex gates a reminder to matching prompts', () => {
+    const body = writeBody('t.md', 'DEPLOY-HELP');
+    const manifest = writeManifest([{ id: 't', trigger: 'deploy', body, cadence: 'every-prompt' }]);
+    const miss = run([], { stdin: { prompt: 'just chatting' }, manifest, sessionId: 's' });
+    assert.doesNotMatch(miss.stdout, /DEPLOY-HELP/);
+    const hit = run([], { stdin: { prompt: 'please deploy the app' }, manifest, sessionId: 's' });
+    assert.match(hit.stdout, /DEPLOY-HELP/);
+  });
+});
+
+describe('combined output + fail-open', () => {
+  it('N firing entries → ONE combined block from ONE process', () => {
+    const b1 = writeBody('1.md', 'ONE-BODY');
+    const b2 = writeBody('2.md', 'TWO-BODY');
+    const b3 = writeBody('3.md', 'THREE-BODY');
+    const manifest = writeManifest([
+      { id: 'r1', trigger: 'always', body: b1, cadence: 'every-prompt' },
+      { id: 'r2', trigger: 'always', body: b2, cadence: 'every-prompt' },
+      { id: 'r3', trigger: 'always', body: b3, cadence: 'every-prompt' },
+    ]);
+    const r = run([], { stdin: { prompt: 'go' }, manifest, sessionId: 's' });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /ONE-BODY/);
+    assert.match(r.stdout, /TWO-BODY/);
+    assert.match(r.stdout, /THREE-BODY/);
+  });
+
+  it('zero firing entries → no output, exit 0', () => {
+    const body = writeBody('n.md', 'NOPE');
+    const manifest = writeManifest([
+      { id: 'n', trigger: 'zzznomatch', body, cadence: 'every-prompt' },
+    ]);
+    const r = run([], { stdin: { prompt: 'hello' }, manifest, sessionId: 's' });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), '');
+  });
+
+  it('empty stdin → fail-open exit 0, no output', () => {
+    const r = run([], { stdin: null });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), '');
+  });
+
+  it('unreadable manifest → fail-open exit 0, no output', () => {
+    const r = run([], {
+      stdin: { prompt: 'hi' },
+      manifest: path.join(tmp, 'does-not-exist.json'),
+      sessionId: 's',
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.stdout.trim(), '');
+  });
+
+  it('one bad entry does not abort the rest (per-entry fail-open)', () => {
+    const good = writeBody('g.md', 'GOOD-BODY');
+    const manifest = writeManifest([
+      { id: 'bad', trigger: '(', body: good, cadence: 'every-prompt' },
+      { id: 'good', trigger: 'always', body: good, cadence: 'every-prompt' },
+    ]);
+    const r = run([], { stdin: { prompt: 'x' }, manifest, sessionId: 's' });
+    assert.equal(r.code, 0);
+    assert.match(r.stdout, /GOOD-BODY/);
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/remind-once.js
+++ b/plugins/work/scripts/workflows/lib/hooks/remind-once.js
@@ -105,13 +105,14 @@ function loadLedger(sessionId) {
   const file = ledgerPath(sessionId);
   let raw;
   try {
-    if (!fs.existsSync(file)) return { ledger: emptyLedger(sessionId) };
-    const st = fs.statSync(file);
-    if (!st.isFile() || st.size <= 0 || st.size > MAX_FILE_BYTES) {
+    // Read directly (no existsSync/stat-then-read TOCTOU): a missing ledger is
+    // the common first-prompt case, handled as ENOENT below.
+    raw = fs.readFileSync(file, 'utf8');
+    if (raw.length <= 0 || Buffer.byteLength(raw) > MAX_FILE_BYTES) {
       return { error: true };
     }
-    raw = fs.readFileSync(file, 'utf8');
   } catch (err) {
+    if (err && err.code === 'ENOENT') return { ledger: emptyLedger(sessionId) };
     log(err);
     return { error: true };
   }

--- a/plugins/work/scripts/workflows/lib/hooks/remind-once.js
+++ b/plugins/work/scripts/workflows/lib/hooks/remind-once.js
@@ -1,0 +1,201 @@
+'use strict';
+
+/**
+ * remind-once — session-scoped reminder ledger primitive (GH-773).
+ *
+ * A generic helper any reminder-style UserPromptSubmit hook consults to decide
+ * whether it has already injected a given reminder THIS session. Keyed by
+ * session id (file) + reminder id (entry) — NEVER by cwd (the GH-583
+ * anti-pattern: two sessions in the same folder must stay distinct, and the
+ * same session across two prompts must dedupe).
+ *
+ * Session-id resolution (matches inject-ledger leg order without the cross-
+ * plugin require): `normalizeHookPayload(payload).sessionId` (payload
+ * `session_id` first, then CLAUDE_CODE_SESSION_ID env) → else a documented
+ * `sha256(cwd + processStart)` degradation. The env leg (CLAUDE_CODE_SESSION_ID)
+ * rotates on `/clear` and per new conversation — exactly the re-arm semantics
+ * a once-per-session reminder needs. The resolved id is sanitized through
+ * SAFE_ID_RE (unsafe → sha256-hashed) before use as a filename (path-traversal
+ * guard).
+ *
+ * Storage: `~/.claude/work-workflow/.reminders/<sessionId>.json`, overridable
+ * via `REMIND_ONCE_SESSION_DIR` for tests. Shape:
+ *   `{ createdAt, sessionId, reminders: { <reminderId>: { firedAt, count } } }`.
+ * Stores reminder ids + counters + timestamps ONLY — no prompt text, no bodies.
+ *
+ * Fail-open discipline: every function returns a safe default on IO error and
+ * never throws. `shouldRemind` on a ledger READ error fails toward `true` so a
+ * transient IO error never silently suppresses a genuine first injection.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+const { normalizeHookPayload } = require('../runtime/payload');
+const { writeJsonAtomic } = require('../safeIO');
+const { logHookError } = require('../hook-error-log');
+
+const SAFE_ID_RE = /^[A-Za-z0-9_-]{1,128}$/;
+const MAX_FILE_BYTES = 64 * 1024;
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const PROCESS_START_TIME = Date.now();
+
+function log(err) {
+  try {
+    logHookError('remind-once', err);
+  } catch {
+    /* fail-open */
+  }
+}
+
+function hashId(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 32);
+}
+
+/** Safe passthrough or sha256-hashed; falls back to the cwd+start hash. */
+function sanitizeSessionId(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return hashId(`${process.cwd()}|${PROCESS_START_TIME}`);
+  }
+  return SAFE_ID_RE.test(raw) ? raw : hashId(raw);
+}
+
+function sessionDir() {
+  if (process.env.REMIND_ONCE_SESSION_DIR) return process.env.REMIND_ONCE_SESSION_DIR;
+  return path.join(os.homedir(), '.claude', 'work-workflow', '.reminders');
+}
+
+function ledgerPath(sessionId) {
+  return path.join(sessionDir(), `${sessionId}.json`);
+}
+
+function ensureDir() {
+  try {
+    fs.mkdirSync(sessionDir(), { recursive: true });
+  } catch (err) {
+    log(err);
+  }
+}
+
+function emptyLedger(sessionId) {
+  return { createdAt: new Date().toISOString(), sessionId: sessionId || '', reminders: {} };
+}
+
+/**
+ * Resolve a session id from the hook payload; degrade to sha256(cwd+start) when
+ * none is resolvable. Always sanitized for safe filename use.
+ */
+function resolveSessionId(payload) {
+  try {
+    const resolved = normalizeHookPayload(payload).sessionId;
+    return sanitizeSessionId(resolved);
+  } catch (err) {
+    log(err);
+    return sanitizeSessionId(null);
+  }
+}
+
+/**
+ * Read + parse a ledger. Returns { ledger } on success/empty, or { error:true }
+ * on a read/parse failure (oversized, unreadable, malformed JSON) so callers
+ * can fail toward emitting.
+ */
+function loadLedger(sessionId) {
+  const file = ledgerPath(sessionId);
+  let raw;
+  try {
+    if (!fs.existsSync(file)) return { ledger: emptyLedger(sessionId) };
+    const st = fs.statSync(file);
+    if (!st.isFile() || st.size <= 0 || st.size > MAX_FILE_BYTES) {
+      return { error: true };
+    }
+    raw = fs.readFileSync(file, 'utf8');
+  } catch (err) {
+    log(err);
+    return { error: true };
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || typeof parsed.reminders !== 'object') {
+      return { error: true };
+    }
+    return { ledger: parsed };
+  } catch (err) {
+    log(err);
+    return { error: true };
+  }
+}
+
+/**
+ * Whether a reminder should fire this prompt. `every-prompt` → always true;
+ * `once-per-session` → true iff no ledger entry exists for the pair. A ledger
+ * READ error fails toward true (never suppresses a genuine first injection).
+ */
+function shouldRemind(sessionId, reminderId, cadence) {
+  if (cadence === 'every-prompt') return true;
+  const result = loadLedger(sessionId);
+  if (result.error) return true;
+  return !result.ledger.reminders[reminderId];
+}
+
+/** Record a fired reminder: write/increment { firedAt, count } atomically. */
+function recordReminder(sessionId, reminderId) {
+  try {
+    ensureDir();
+    const result = loadLedger(sessionId);
+    const ledger = result.error ? emptyLedger(sessionId) : result.ledger;
+    const prev = ledger.reminders[reminderId];
+    ledger.reminders[reminderId] = {
+      firedAt: new Date().toISOString(),
+      count: (prev && Number(prev.count) ? Number(prev.count) : 0) + 1,
+    };
+    writeJsonAtomic(ledgerPath(sessionId), ledger, { compact: true });
+  } catch (err) {
+    log(err);
+  }
+}
+
+/** Re-arm all once-per-session reminders for a session (removes its ledger). */
+function resetForSession(sessionId) {
+  try {
+    fs.rmSync(ledgerPath(sessionId), { force: true });
+  } catch (err) {
+    log(err);
+  }
+}
+
+/** Delete ledger files older than maxAgeMs (7-day default). Fail-open per-file. */
+function gcStaleLedgers(opts) {
+  try {
+    const maxAgeMs = (opts && Number(opts.maxAgeMs)) || DEFAULT_MAX_AGE_MS;
+    const dir = sessionDir();
+    let entries;
+    try {
+      entries = fs.readdirSync(dir);
+    } catch {
+      return;
+    }
+    const cutoff = Date.now() - maxAgeMs;
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      const p = path.join(dir, name);
+      try {
+        if (fs.statSync(p).mtimeMs < cutoff) fs.rmSync(p, { force: true });
+      } catch {
+        /* fail-open per-file */
+      }
+    }
+  } catch (err) {
+    log(err);
+  }
+}
+
+module.exports = {
+  SAFE_ID_RE,
+  resolveSessionId,
+  shouldRemind,
+  recordReminder,
+  resetForSession,
+  gcStaleLedgers,
+};

--- a/plugins/work/scripts/workflows/lib/hooks/remind-once.js
+++ b/plugins/work/scripts/workflows/lib/hooks/remind-once.js
@@ -166,23 +166,29 @@ function resetForSession(sessionId) {
   }
 }
 
+/** Whether the ledger file at `p` is older than `cutoff` (fail-open: false). */
+function isStaleLedger(p, cutoff) {
+  try {
+    return fs.statSync(p).mtimeMs < cutoff;
+  } catch {
+    return false;
+  }
+}
+
 /** Delete ledger files older than maxAgeMs (7-day default). Fail-open per-file. */
 function gcStaleLedgers(opts) {
   try {
     const maxAgeMs = (opts && Number(opts.maxAgeMs)) || DEFAULT_MAX_AGE_MS;
-    const dir = sessionDir();
-    let entries;
-    try {
-      entries = fs.readdirSync(dir);
-    } catch {
-      return;
-    }
     const cutoff = Date.now() - maxAgeMs;
-    for (const name of entries) {
-      if (!name.endsWith('.json')) continue;
-      const p = path.join(dir, name);
+    const dir = sessionDir();
+    const stale = fs
+      .readdirSync(dir)
+      .filter((name) => name.endsWith('.json'))
+      .map((name) => path.join(dir, name))
+      .filter((p) => isStaleLedger(p, cutoff));
+    for (const p of stale) {
       try {
-        if (fs.statSync(p).mtimeMs < cutoff) fs.rmSync(p, { force: true });
+        fs.rmSync(p, { force: true });
       } catch {
         /* fail-open per-file */
       }

--- a/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
@@ -122,9 +122,10 @@ function validateManifest(mPath) {
 
 function readBody(bodyPath) {
   try {
-    const st = fs.statSync(bodyPath);
-    if (!st.isFile() || st.size <= 0 || st.size > MAX_BODY_BYTES) return null;
-    return fs.readFileSync(bodyPath, 'utf8').trim();
+    // Read directly (no stat-then-read TOCTOU), then size-cap the content.
+    const raw = fs.readFileSync(bodyPath, 'utf8');
+    if (raw.length <= 0 || Buffer.byteLength(raw) > MAX_BODY_BYTES) return null;
+    return raw.trim();
   } catch (err) {
     log(err);
     return null;

--- a/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
@@ -173,8 +173,18 @@ function parsePayload(raw) {
 function runHook() {
   const payload = parsePayload(readStdin());
   if (!payload) return process.exit(0);
+  // Best-effort GC of ledgers from long-dead sessions (cheap mtime dir scan);
+  // without this the per-session ledger files would accumulate forever.
+  try {
+    remindOnce.gcStaleLedgers();
+  } catch {
+    /* best-effort cleanup — never blocks the prompt */
+  }
   const prompt = typeof payload.prompt === 'string' ? payload.prompt : '';
-  const { entries } = validateManifest(manifestPath());
+  const { entries, errors } = validateManifest(manifestPath());
+  // Surface broken manifest entries to the hook error log (not just the CLI
+  // validate path) so a bad regex / renamed body / typo'd cadence is diagnosable.
+  for (const e of errors) log(new Error(`manifest entry "${e.id}": ${e.error}`));
   if (entries.length === 0) return process.exit(0);
   const sessionId = remindOnce.resolveSessionId(payload);
   const { blocks, toRecord } = collectFired(entries, prompt, sessionId);

--- a/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
@@ -64,26 +64,36 @@ function resolveBodyPath(mPath, body) {
   return resolved;
 }
 
+/** Shape check for the string identity fields. Returns an error string or null. */
+function entryShapeError(raw) {
+  if (!raw || typeof raw !== 'object') return 'missing or invalid id';
+  if (typeof raw.id !== 'string' || !raw.id) return 'missing or invalid id';
+  if (typeof raw.trigger !== 'string' || !raw.trigger) return 'missing trigger';
+  return null;
+}
+
+/** Compile a trigger to a regex (null for "always"). Returns { regex } or { error }. */
+function compileTrigger(trigger) {
+  if (trigger === 'always') return { regex: null };
+  try {
+    return { regex: new RegExp(trigger) };
+  } catch {
+    return { error: `bad trigger regex "${trigger}"` };
+  }
+}
+
 /** Validate one entry against the manifest path. Returns { entry } or { error }. */
 function validateEntry(raw, mPath) {
-  if (!raw || typeof raw !== 'object' || typeof raw.id !== 'string' || !raw.id) {
-    return { error: 'missing or invalid id' };
-  }
-  if (typeof raw.trigger !== 'string' || !raw.trigger) return { error: 'missing trigger' };
+  const shapeErr = entryShapeError(raw);
+  if (shapeErr) return { error: shapeErr };
   const cadence = raw.cadence === undefined ? 'once-per-session' : raw.cadence;
   if (!VALID_CADENCES.has(cadence)) return { error: `unknown cadence "${raw.cadence}"` };
-  let regex = null;
-  if (raw.trigger !== 'always') {
-    try {
-      regex = new RegExp(raw.trigger);
-    } catch {
-      return { error: `bad trigger regex "${raw.trigger}"` };
-    }
-  }
+  const compiled = compileTrigger(raw.trigger);
+  if (compiled.error) return { error: compiled.error };
   const bodyPath = typeof raw.body === 'string' ? resolveBodyPath(mPath, raw.body) : null;
   if (!bodyPath) return { error: 'body path missing or escapes allowed dir' };
   if (!fs.existsSync(bodyPath)) return { error: `body file not found: ${raw.body}` };
-  return { entry: { id: raw.id, trigger: raw.trigger, regex, cadence, bodyPath } };
+  return { entry: { id: raw.id, trigger: raw.trigger, regex: compiled.regex, cadence, bodyPath } };
 }
 
 /**

--- a/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
+++ b/plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+
+'use strict';
+
+/**
+ * reminder-dispatcher.js — the single consolidated UserPromptSubmit reminder
+ * hook (GH-773). Replaces the "N standalone prompt-reminder hooks = N processes
+ * re-injecting static context every prompt" pattern with ONE process that:
+ *
+ *   1. reads stdin JSON (fail-open exit 0 on empty/parse error);
+ *   2. resolves the manifest path (`REMINDER_MANIFEST` env → shipped default);
+ *   3. validates each entry, dropping only the bad ones (per-entry fail-open);
+ *   4. resolves the session id once via remind-once;
+ *   5. filters entries by trigger regex + per-session cadence (remind-once);
+ *   6. concatenates the surviving bodies into ONE context block emitted via
+ *      getRuntime(payload).emit.context('UserPromptSubmit', block); zero firing
+ *      entries → emits nothing, exit 0;
+ *   7. records each fired once-per-session entry.
+ *
+ * Manifest entry: `{ id, trigger: "always"|<regex string>, body: <path>,
+ * cadence?: "once-per-session"|"every-prompt" }`. `cadence` defaults to
+ * `once-per-session`. Any manifest/IO/parse error degrades to the remaining
+ * valid entries or no output — it NEVER blocks the prompt.
+ *
+ * CLI: `node reminder-dispatcher.js validate <manifest>` → exit 0 valid,
+ * exit 1 with per-entry diagnostics (CI-usable).
+ *
+ * Node built-ins only; reuses normalizeHookPayload path (via remind-once),
+ * getRuntime, and logHookError.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { getRuntime } = require('../runtime');
+const { logHookError } = require('../hook-error-log');
+const remindOnce = require('./remind-once');
+
+const DEFAULT_MANIFEST = path.join(__dirname, 'reminders.manifest.json');
+const MAX_BODY_BYTES = 64 * 1024;
+const VALID_CADENCES = new Set(['once-per-session', 'every-prompt']);
+
+function log(err) {
+  try {
+    logHookError('reminder-dispatcher', err);
+  } catch {
+    /* fail-open */
+  }
+}
+
+function manifestPath() {
+  return process.env.REMINDER_MANIFEST || DEFAULT_MANIFEST;
+}
+
+/** Directory a body path must stay within (the manifest's own directory tree). */
+function allowedRoot(mPath) {
+  return path.resolve(path.dirname(mPath));
+}
+
+function resolveBodyPath(mPath, body) {
+  const root = allowedRoot(mPath);
+  const resolved = path.resolve(root, body);
+  const rel = path.relative(root, resolved);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) return null;
+  return resolved;
+}
+
+/** Validate one entry against the manifest path. Returns { entry } or { error }. */
+function validateEntry(raw, mPath) {
+  if (!raw || typeof raw !== 'object' || typeof raw.id !== 'string' || !raw.id) {
+    return { error: 'missing or invalid id' };
+  }
+  if (typeof raw.trigger !== 'string' || !raw.trigger) return { error: 'missing trigger' };
+  const cadence = raw.cadence === undefined ? 'once-per-session' : raw.cadence;
+  if (!VALID_CADENCES.has(cadence)) return { error: `unknown cadence "${raw.cadence}"` };
+  let regex = null;
+  if (raw.trigger !== 'always') {
+    try {
+      regex = new RegExp(raw.trigger);
+    } catch {
+      return { error: `bad trigger regex "${raw.trigger}"` };
+    }
+  }
+  const bodyPath = typeof raw.body === 'string' ? resolveBodyPath(mPath, raw.body) : null;
+  if (!bodyPath) return { error: 'body path missing or escapes allowed dir' };
+  if (!fs.existsSync(bodyPath)) return { error: `body file not found: ${raw.body}` };
+  return { entry: { id: raw.id, trigger: raw.trigger, regex, cadence, bodyPath } };
+}
+
+/**
+ * Parse + validate a manifest. Returns { entries: [...valid], errors: [{id, error}] }.
+ * A manifest that is unreadable / not an array yields empty entries + one error.
+ */
+function validateManifest(mPath) {
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(mPath, 'utf8'));
+  } catch (err) {
+    return { entries: [], errors: [{ id: '<manifest>', error: `unreadable: ${err.message}` }] };
+  }
+  if (!Array.isArray(parsed)) {
+    return { entries: [], errors: [{ id: '<manifest>', error: 'manifest is not an array' }] };
+  }
+  const entries = [];
+  const errors = [];
+  for (const raw of parsed) {
+    const result = validateEntry(raw, mPath);
+    if (result.error) errors.push({ id: (raw && raw.id) || '<unknown>', error: result.error });
+    else entries.push(result.entry);
+  }
+  return { entries, errors };
+}
+
+function readBody(bodyPath) {
+  try {
+    const st = fs.statSync(bodyPath);
+    if (!st.isFile() || st.size <= 0 || st.size > MAX_BODY_BYTES) return null;
+    return fs.readFileSync(bodyPath, 'utf8').trim();
+  } catch (err) {
+    log(err);
+    return null;
+  }
+}
+
+/** Whether an entry should fire for this prompt + session. */
+function entryFires(entry, prompt, sessionId) {
+  if (entry.regex && !entry.regex.test(prompt)) return false;
+  return remindOnce.shouldRemind(sessionId, entry.id, entry.cadence);
+}
+
+/** Collect the fired entries' bodies and the ids to record. */
+function collectFired(entries, prompt, sessionId) {
+  const blocks = [];
+  const toRecord = [];
+  for (const entry of entries) {
+    if (!entryFires(entry, prompt, sessionId)) continue;
+    const body = readBody(entry.bodyPath);
+    if (!body) continue;
+    blocks.push(body);
+    if (entry.cadence === 'once-per-session') toRecord.push(entry.id);
+  }
+  return { blocks, toRecord };
+}
+
+function readStdin() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function parsePayload(raw) {
+  if (!raw || !raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/** Hook path: stdin → manifest → filter → combine → emit. Always exit 0. */
+function runHook() {
+  const payload = parsePayload(readStdin());
+  if (!payload) return process.exit(0);
+  const prompt = typeof payload.prompt === 'string' ? payload.prompt : '';
+  const { entries } = validateManifest(manifestPath());
+  if (entries.length === 0) return process.exit(0);
+  const sessionId = remindOnce.resolveSessionId(payload);
+  const { blocks, toRecord } = collectFired(entries, prompt, sessionId);
+  if (blocks.length === 0) return process.exit(0);
+  const block = blocks.join('\n\n');
+  getRuntime(payload).emit.context('UserPromptSubmit', block);
+  for (const id of toRecord) remindOnce.recordReminder(sessionId, id);
+  process.exit(0);
+}
+
+/** CLI: validate a manifest. Exit 0 clean, exit 1 with per-entry diagnostics. */
+function runValidate(mPath) {
+  const target = mPath || manifestPath();
+  const { entries, errors } = validateManifest(target);
+  if (errors.length === 0) {
+    process.stdout.write(`ok: ${entries.length} valid entr${entries.length === 1 ? 'y' : 'ies'}\n`);
+    return process.exit(0);
+  }
+  for (const e of errors) process.stderr.write(`invalid entry "${e.id}": ${e.error}\n`);
+  return process.exit(1);
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  if (argv[0] === 'validate') return runValidate(argv[1]);
+  return runHook();
+}
+
+try {
+  main();
+} catch (err) {
+  log(err);
+  process.exit(0);
+}
+
+module.exports = { validateManifest, validateEntry, resolveBodyPath };

--- a/plugins/work/scripts/workflows/lib/hooks/reminders.manifest.json
+++ b/plugins/work/scripts/workflows/lib/hooks/reminders.manifest.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "agent-picker",
+    "trigger": "always",
+    "body": "reminders/agent-picker.reminder.md",
+    "cadence": "once-per-session"
+  }
+]

--- a/plugins/work/scripts/workflows/lib/hooks/reminders/agent-picker.reminder.md
+++ b/plugins/work/scripts/workflows/lib/hooks/reminders/agent-picker.reminder.md
@@ -1,0 +1,4 @@
+Agent selection reminder (once-per-session): pick the specialized agent whose
+expertise matches the task — commit-writer for commit messages, pr-generator
+for PR descriptions, a domain developer agent for implementation, and the
+requirements-verifier + code-checker gates before declaring a task complete.


### PR DESCRIPTION
## Existing Behavior

- Each UserPromptSubmit reminder hook ran as its own separate process, spawning N processes and re-injecting identical static context on every prompt turn.
- Reminder deduplication was absent or keyed by cwd (the GH-583 anti-pattern), causing two sessions sharing the same working folder to incorrectly share a suppression state.
- No unified manifest format existed for declaring and managing reminder entries; each hook was a standalone script.

## Intended New Behavior

- A single reminder-dispatcher.js hook replaces all standalone UserPromptSubmit reminder hooks — one process per prompt regardless of manifest size, emitting one combined context block.
- A remind-once.js ledger primitive keys suppression by **session id + reminder id** (never cwd): two sessions in the same folder stay independent, and the same session dedupes across prompts. Session ids come from normalizeHookPayload(payload).sessionId and rotate on /clear or a new conversation, re-arming all once-per-session reminders automatically.
- A JSON manifest (reminders.manifest.json) declares entries with id, trigger (regex or always), body (path to a markdown file), and optional cadence (once-per-session | every-prompt, defaulting to once-per-session). A validate CLI subcommand enables CI validation.
- The dispatcher is fail-open at every layer: bad regex, missing body, unreadable manifest, empty stdin — each drops only the affected entry or exits 0 cleanly, never blocking the prompt.
- Ships a starter manifest entry and a migration guide in plugins/work/docs/hooks.md describing how personal prompt-reminder.sh-style hooks are ported to manifest entries.

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

### Backend / hook behavior

1. Install the plugin. The new UserPromptSubmit entry in hooks.json wires reminder-dispatcher.js automatically.
2. Open a fresh Claude Code session. On the first prompt the reminder block fires exactly once.
3. Send a second prompt in the same session — the reminder is suppressed (ledger entry present, count: 1).
4. Run /clear or open a new conversation. The session id rotates; the reminder fires again on the next prompt.
5. Verify isolation: open a second terminal in the same directory as the first session. Start a new session there. Confirm it fires independently (different sessionId.json file in the ledger dir).

### Validate CLI

```bash
node plugins/work/scripts/workflows/lib/hooks/reminder-dispatcher.js validate \
  plugins/work/scripts/workflows/lib/hooks/reminders.manifest.json
```

Expected: ok: 1 valid entry — exit 0.

### Environment variable overrides

- REMINDER_MANIFEST=<path> — point the dispatcher at a custom manifest.
- REMIND_ONCE_SESSION_DIR=<dir> — redirect ledger files (used by tests for isolation).

### Test Results

25 unit and integration tests across three test files. All pass at --test-concurrency=1.

Files:
- plugins/work/scripts/workflows/lib/hooks/__tests__/remind-once.test.js
- plugins/work/scripts/workflows/lib/hooks/__tests__/reminder-dispatcher.integration.test.js
- plugins/work/scripts/workflows/lib/hooks/__tests__/hooks-json-dispatcher.test.js

Closes #773