### PR TITLE
feat(hooks): codex-runtime runHook wrapper + replay harness (GH-774)

### DIFF
--- a/factories/runtime/__tests__/run-hook.spec.js
+++ b/factories/runtime/__tests__/run-hook.spec.js
@@ -1,0 +1,210 @@
+'use strict';
+
+/**
+ * Tests for factories/runtime/run-hook.js — the runtime-aware hook wrapper
+ * (GH-774). Pure event resolution + defensive parse are unit-tested; the
+ * fail-open / fail-closed / event-from-payload contracts are exercised by
+ * spawning real hook scripts that require the factory by absolute path, since
+ * those behaviors terminate the process.
+ *
+ * Run: node --test factories/runtime/__tests__/run-hook.spec.js
+ */
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const RUN_HOOK_PATH = require.resolve('../run-hook');
+const { resolveEvent, parsePayload } = require('../run-hook');
+
+// --------------------------------------------------------------------------
+// Unit: resolveEvent precedence + parsePayload defensiveness.
+// --------------------------------------------------------------------------
+
+describe('resolveEvent — payload-first precedence (codex omits CLAUDE_HOOK_TYPE)', () => {
+  it('opts.event wins over every other source', () => {
+    const raw = { hook_event_name: 'PostToolUse' };
+    assert.equal(resolveEvent(raw, { event: 'Stop' }, { CLAUDE_HOOK_TYPE: 'PreToolUse' }), 'Stop');
+  });
+
+  it('CLAUDE_HOOK_TYPE env is used when opts.event is absent', () => {
+    const raw = { hook_event_name: 'PostToolUse' };
+    assert.equal(resolveEvent(raw, {}, { CLAUDE_HOOK_TYPE: 'PreToolUse' }), 'PreToolUse');
+  });
+
+  it('payload.hook_event_name resolves the event when the env is unset (codex)', () => {
+    assert.equal(resolveEvent({ hook_event_name: 'Stop' }, {}, {}), 'Stop');
+  });
+
+  it('falls back to opts.defaultEvent when nothing else resolves', () => {
+    assert.equal(resolveEvent({}, { defaultEvent: 'PostToolUse' }, {}), 'PostToolUse');
+  });
+
+  it('returns null when no source provides an event', () => {
+    assert.equal(resolveEvent({}, {}, {}), null);
+  });
+
+  it('ignores a non-string hook_event_name', () => {
+    assert.equal(resolveEvent({ hook_event_name: 42 }, { defaultEvent: 'Stop' }, {}), 'Stop');
+  });
+});
+
+describe('parsePayload — never throws', () => {
+  it('parses well-formed JSON', () => {
+    assert.deepEqual(parsePayload('{"a":1}'), { a: 1 });
+  });
+
+  it('returns {} for empty and malformed input', () => {
+    assert.deepEqual(parsePayload(''), {});
+    assert.deepEqual(parsePayload('{nope'), {});
+  });
+
+  it('honors a caller fallback', () => {
+    const fb = { d: true };
+    assert.equal(parsePayload('', fb), fb);
+  });
+});
+
+// --------------------------------------------------------------------------
+// End-to-end: spawned hook scripts (behaviors that exit the process).
+// --------------------------------------------------------------------------
+
+function writeHookScript(dir, name, body) {
+  const file = path.join(dir, name);
+  const src = [
+    "'use strict';",
+    `const { runHook } = require(${JSON.stringify(RUN_HOOK_PATH)});`,
+    body,
+    '',
+  ].join('\n');
+  fs.writeFileSync(file, src);
+  return file;
+}
+
+function spawnHook(script, input, extraEnv) {
+  const env = { ...process.env, ...extraEnv };
+  delete env.ENFORCE_HOOK_DEBUG;
+  for (const key of ['CLAUDE_HOOK_TYPE', 'AGENT_RUNTIME', 'CLAUDECODE', 'CLAUDE_CODE_SESSION_ID']) {
+    if (!(extraEnv && key in extraEnv)) delete env[key];
+  }
+  return spawnSync(process.execPath, [script], { input, env, encoding: 'utf8', timeout: 15000 });
+}
+
+describe('runHook end-to-end (spawned hook scripts)', () => {
+  let dir;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'run-hook-'));
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves the event from the codex payload (no CLAUDE_HOOK_TYPE env)', () => {
+    const side = path.join(dir, 'ctx.json');
+    const script = writeHookScript(
+      dir,
+      'echo.js',
+      [
+        "const fs = require('fs');",
+        'runHook(({ event, evt, rt }) => {',
+        `  fs.writeFileSync(${JSON.stringify(side)}, JSON.stringify({ event, evtEvent: evt.event, runtime: rt.name }));`,
+        '});',
+      ].join('\n')
+    );
+    const payload = { hook_event_name: 'Stop', turn_id: 't-1', session_id: 's' };
+    const res = spawnHook(script, JSON.stringify(payload), {});
+    assert.equal(res.status, 0);
+    assert.equal(res.stderr, '');
+    const ctx = JSON.parse(fs.readFileSync(side, 'utf8'));
+    assert.equal(ctx.event, 'Stop');
+    assert.equal(ctx.evtEvent, 'Stop');
+    assert.equal(ctx.runtime, 'codex', 'turn_id must sniff codex');
+  });
+
+  it('malformed stdin → handler receives raw {} and exits 0', () => {
+    const side = path.join(dir, 'ctx.json');
+    const script = writeHookScript(
+      dir,
+      'echo.js',
+      [
+        "const fs = require('fs');",
+        'runHook(({ raw }) => {',
+        `  fs.writeFileSync(${JSON.stringify(side)}, JSON.stringify(raw));`,
+        '}, { defaultEvent: "PostToolUse" });',
+      ].join('\n')
+    );
+    const res = spawnHook(script, '{bad', {});
+    assert.equal(res.status, 0);
+    assert.equal(res.stderr, '');
+    assert.deepEqual(JSON.parse(fs.readFileSync(side, 'utf8')), {});
+  });
+
+  it("throwing handler, onError 'open' → exit 0 with EMPTY stdout+stderr", () => {
+    const log = path.join(dir, 'err.log');
+    const script = writeHookScript(
+      dir,
+      'boom.js',
+      [
+        `const { logHookError } = require(${JSON.stringify(require.resolve('../../hookEntrypoint/logHookError'))});`,
+        'runHook(() => { console.log("SHOULD NOT APPEAR"); throw new Error("kaboom-open"); },',
+        '  { defaultEvent: "Stop", logError: logHookError, file: "boom.js" });',
+      ].join('\n')
+    );
+    const res = spawnHook(script, JSON.stringify({ hook_event_name: 'Stop' }), {
+      HOOK_ERROR_LOG: log,
+    });
+    assert.equal(res.status, 0, 'fail-open must exit 0');
+    assert.equal(res.stderr, '', 'fail-open writes nothing to stderr');
+    assert.ok(fs.existsSync(log), 'error is logged to file');
+    assert.ok(fs.readFileSync(log, 'utf8').includes('kaboom-open'));
+  });
+
+  it("throwing handler, onError 'closed' → exit 2 with NON-EMPTY stderr (block preserved)", () => {
+    const script = writeHookScript(
+      dir,
+      'block.js',
+      [
+        'runHook(() => { throw new Error("intentional-block"); },',
+        '  { defaultEvent: "PreToolUse", onError: "closed" });',
+      ].join('\n')
+    );
+    const res = spawnHook(script, JSON.stringify({ hook_event_name: 'PreToolUse' }), {});
+    assert.equal(res.status, 2);
+    assert.ok(res.stderr.includes('intentional-block'));
+  });
+
+  it("onError 'closed' pads a message-less throw so stderr is never empty", () => {
+    const script = writeHookScript(
+      dir,
+      'block-empty.js',
+      ['runHook(() => { throw new Error(""); }, { onError: "closed" });'].join('\n')
+    );
+    const res = spawnHook(script, JSON.stringify({ hook_event_name: 'PreToolUse' }), {});
+    assert.equal(res.status, 2);
+    assert.ok(res.stderr.trim().length > 0);
+  });
+
+  it("a handler's own process.exit wins over runHook's fallthrough", () => {
+    const script = writeHookScript(
+      dir,
+      'self-exit.js',
+      ['runHook(({ rt }) => { rt.emit.block("blocked-by-emit"); });'].join('\n')
+    );
+    const res = spawnHook(script, JSON.stringify({ hook_event_name: 'Stop' }), {});
+    assert.equal(res.status, 2);
+    assert.ok(res.stderr.includes('blocked-by-emit'));
+  });
+
+  it('missing handler throws TypeError synchronously', () => {
+    const script = writeHookScript(dir, 'bad-config.js', [
+      'try { runHook(null); } catch (e) { process.stderr.write("CFG:" + e.constructor.name); process.exit(9); }',
+    ]);
+    const res = spawnHook(script, '{}', {});
+    assert.equal(res.status, 9);
+    assert.ok(res.stderr.includes('CFG:TypeError'));
+  });
+});

--- a/factories/runtime/__tests__/vendored-parity.spec.js
+++ b/factories/runtime/__tests__/vendored-parity.spec.js
@@ -40,6 +40,7 @@ const EXPECTED_MASTER_FILES = {
     'envconfig-lite.js',
     'index.js',
     'payload.js',
+    'run-hook.js',
     'tickets.js',
     'tools.js',
     'transcript-claude.js',

--- a/factories/runtime/index.js
+++ b/factories/runtime/index.js
@@ -166,4 +166,9 @@ module.exports = {
   readStamp,
   stampPath,
   resolveMode,
+  // GH-774: the runtime-aware hook wrapper. Lazily required so index.js does
+  // not eagerly load run-hook (which requires index.js back) at module init.
+  get runHook() {
+    return require('./run-hook').runHook;
+  },
 };

--- a/factories/runtime/run-hook.js
+++ b/factories/runtime/run-hook.js
@@ -1,0 +1,166 @@
+'use strict';
+
+/**
+ * run-hook.js — the runtime-aware hook entry wrapper (GH-774).
+ *
+ * `hookEntrypoint/runHook` pins the stdin → parse → guarded-handler → exit
+ * protocol but knows nothing about the dual-runtime world: it does not detect
+ * the runtime, does not resolve the hook event when the host omits the
+ * `CLAUDE_HOOK_TYPE` env (codex sets none of the CLAUDE_* vars — ground truth
+ * §2.7.2), and does not normalize the two runtimes' divergent payload shapes.
+ * Under codex those gaps are the observed crashes: a Stop hook that reads the
+ * event from env alone falls through to its CLI branch and exits 1
+ * ("Stop hook failed: exited with code 1").
+ *
+ * `runHook(handler, opts)` closes those gaps in one place:
+ *
+ *  1. Stdin is drained defensively (TTY guard; a stream error resolves '').
+ *  2. The payload is parsed with a never-throw JSON parse → `{}` on garbage.
+ *  3. The runtime is detected from the RAW payload (getRuntime) before any
+ *     field is read, so detection sees turn_id / rollout transcript markers.
+ *  4. The event is resolved payload-first: opts.event → CLAUDE_HOOK_TYPE env →
+ *     payload.hook_event_name → opts.defaultEvent. Never depends on the env
+ *     alone, which codex does not set.
+ *  5. The raw payload is normalized to the CanonicalHookEvent shape; missing
+ *     or renamed fields DEGRADE to null/defaults and never throw.
+ *  6. The handler is invoked with { rt, evt, event, raw } and may be sync or
+ *     async. It may exit the process itself (the emit facet does); runHook's
+ *     own exit is the fallthrough.
+ *  7. A handler that resolves without exiting → exit 0.
+ *  8. A handler that throws:
+ *       - onError 'open' (default): logError(file, err) then exit 0 with
+ *         NOTHING on stdout/stderr — the fail-open advisory contract.
+ *       - onError 'closed': a NON-EMPTY line on stderr (padded) then exit 2,
+ *         preserving intentional blocking semantics.
+ *
+ * `logError` is injectable so this module keeps the runtime factory's
+ * zero-cross-vendor-dependency invariant; hook scripts pass their vendored
+ * `logHookError`. When omitted, errors are swallowed (fail-open still holds).
+ */
+
+const { getRuntime } = require('./index');
+
+const VALID_ON_ERROR = new Set(['open', 'closed']);
+const CLOSED_FALLBACK = 'hook handler failed without an error message';
+
+/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the raw hook payload text from stdin. TTY guard: an interactive
+ * invocation (nothing piped) resolves '' instead of hanging forever.
+ */
+async function readStdin(stdin = process.stdin) {
+  if (stdin.isTTY) return '';
+  return collectStream(stdin);
+}
+
+/** Parse a hook payload. Never throws — empty/garbage yields the fallback. */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the hook event without depending on CLAUDE_HOOK_TYPE alone (codex
+ * omits it): explicit opt → env → payload.hook_event_name → default.
+ */
+function resolveEvent(raw, opts, env) {
+  const fromEnv = env.CLAUDE_HOOK_TYPE;
+  const fromPayload = raw && typeof raw.hook_event_name === 'string' ? raw.hook_event_name : null;
+  return opts.event || fromEnv || fromPayload || opts.defaultEvent || null;
+}
+
+function assertConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('runHook: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (!VALID_ON_ERROR.has(mode)) {
+    throw new TypeError("runHook: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Extract a printable message from an arbitrary thrown value; never throws. */
+function safeMessage(err) {
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    return raw.trim() ? raw : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fail-closed exit: stderr MUST be non-empty or the block may not register on
+ * some host runtimes (an empty stderr flips exit-2 back to fail-open).
+ */
+function exitClosed(err) {
+  process.stderr.write(`${safeMessage(err) || CLOSED_FALLBACK}\n`);
+  process.exit(2);
+}
+
+/** Fail-open exit: log (guarded) then exit 0 with silent stdout/stderr. */
+function exitOpen(logError, file, err) {
+  try {
+    if (typeof logError === 'function') logError(file, err);
+  } catch {
+    /* logging must never break fail-open */
+  }
+  process.exit(0);
+}
+
+/** Build the { rt, evt, event, raw } context handed to a hook handler. */
+function buildContext(raw, opts, env) {
+  const rt = getRuntime(raw);
+  const event = resolveEvent(raw, opts, env);
+  const evt = rt.normalizeHookPayload(raw, event ? { event } : {});
+  return { rt, evt, event, raw };
+}
+
+async function dispatch(handler, mode, opts, env) {
+  const raw = parsePayload(await readStdin(opts.stdin));
+  try {
+    await handler(buildContext(raw, opts, env));
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    exitOpen(opts.logError, opts.file || 'runHook', err);
+    return;
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the runtime-aware entry protocol.
+ *
+ * @param {(ctx: {rt: object, evt: object, event: string|null, raw: object}) => any} handler
+ * @param {object} [opts]
+ * @param {string} [opts.event] - Force the hook event (highest precedence).
+ * @param {string} [opts.defaultEvent] - Event when nothing else resolves one.
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {(file: string, err: unknown) => void} [opts.logError] - Error sink.
+ * @param {string} [opts.file] - Source label for the error log.
+ * @param {NodeJS.ReadStream} [opts.stdin] - Injectable stdin (tests).
+ * @param {NodeJS.ProcessEnv} [opts.env] - Injectable env (tests).
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertConfig(handler, options);
+  const env = options.env || process.env;
+  return dispatch(handler, mode, options, env);
+}
+
+module.exports = { runHook, readStdin, parsePayload, resolveEvent };

--- a/factories/runtime/run-hook.js
+++ b/factories/runtime/run-hook.js
@@ -43,15 +43,21 @@ const { getRuntime } = require('./index');
 const VALID_ON_ERROR = new Set(['open', 'closed']);
 const CLOSED_FALLBACK = 'hook handler failed without an error message';
 
-/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
-function collectStream(stream) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', () => resolve(''));
-  });
+/**
+ * Drain a readable stream to utf8; a stream error yields '' (never rejects).
+ * Uses the async-iterator idiom deliberately: this factory is vendored to
+ * maestro, which does NOT carry hookEntrypoint.js, so run-hook must stay
+ * self-contained rather than reuse that module's event-handler collectStream.
+ */
+async function collectStream(stream) {
+  stream.setEncoding('utf8');
+  let data = '';
+  try {
+    for await (const chunk of stream) data += chunk;
+  } catch {
+    return '';
+  }
+  return data;
 }
 
 /**

--- a/plugins/heimdall/lib/runtime/index.js
+++ b/plugins/heimdall/lib/runtime/index.js
@@ -168,4 +168,9 @@ module.exports = {
   readStamp,
   stampPath,
   resolveMode,
+  // GH-774: the runtime-aware hook wrapper. Lazily required so index.js does
+  // not eagerly load run-hook (which requires index.js back) at module init.
+  get runHook() {
+    return require('./run-hook').runHook;
+  },
 };

--- a/plugins/heimdall/lib/runtime/run-hook.js
+++ b/plugins/heimdall/lib/runtime/run-hook.js
@@ -1,0 +1,168 @@
+// GENERATED — edit factories/runtime/run-hook.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * run-hook.js — the runtime-aware hook entry wrapper (GH-774).
+ *
+ * `hookEntrypoint/runHook` pins the stdin → parse → guarded-handler → exit
+ * protocol but knows nothing about the dual-runtime world: it does not detect
+ * the runtime, does not resolve the hook event when the host omits the
+ * `CLAUDE_HOOK_TYPE` env (codex sets none of the CLAUDE_* vars — ground truth
+ * §2.7.2), and does not normalize the two runtimes' divergent payload shapes.
+ * Under codex those gaps are the observed crashes: a Stop hook that reads the
+ * event from env alone falls through to its CLI branch and exits 1
+ * ("Stop hook failed: exited with code 1").
+ *
+ * `runHook(handler, opts)` closes those gaps in one place:
+ *
+ *  1. Stdin is drained defensively (TTY guard; a stream error resolves '').
+ *  2. The payload is parsed with a never-throw JSON parse → `{}` on garbage.
+ *  3. The runtime is detected from the RAW payload (getRuntime) before any
+ *     field is read, so detection sees turn_id / rollout transcript markers.
+ *  4. The event is resolved payload-first: opts.event → CLAUDE_HOOK_TYPE env →
+ *     payload.hook_event_name → opts.defaultEvent. Never depends on the env
+ *     alone, which codex does not set.
+ *  5. The raw payload is normalized to the CanonicalHookEvent shape; missing
+ *     or renamed fields DEGRADE to null/defaults and never throw.
+ *  6. The handler is invoked with { rt, evt, event, raw } and may be sync or
+ *     async. It may exit the process itself (the emit facet does); runHook's
+ *     own exit is the fallthrough.
+ *  7. A handler that resolves without exiting → exit 0.
+ *  8. A handler that throws:
+ *       - onError 'open' (default): logError(file, err) then exit 0 with
+ *         NOTHING on stdout/stderr — the fail-open advisory contract.
+ *       - onError 'closed': a NON-EMPTY line on stderr (padded) then exit 2,
+ *         preserving intentional blocking semantics.
+ *
+ * `logError` is injectable so this module keeps the runtime factory's
+ * zero-cross-vendor-dependency invariant; hook scripts pass their vendored
+ * `logHookError`. When omitted, errors are swallowed (fail-open still holds).
+ */
+
+const { getRuntime } = require('./index');
+
+const VALID_ON_ERROR = new Set(['open', 'closed']);
+const CLOSED_FALLBACK = 'hook handler failed without an error message';
+
+/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the raw hook payload text from stdin. TTY guard: an interactive
+ * invocation (nothing piped) resolves '' instead of hanging forever.
+ */
+async function readStdin(stdin = process.stdin) {
+  if (stdin.isTTY) return '';
+  return collectStream(stdin);
+}
+
+/** Parse a hook payload. Never throws — empty/garbage yields the fallback. */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the hook event without depending on CLAUDE_HOOK_TYPE alone (codex
+ * omits it): explicit opt → env → payload.hook_event_name → default.
+ */
+function resolveEvent(raw, opts, env) {
+  const fromEnv = env.CLAUDE_HOOK_TYPE;
+  const fromPayload = raw && typeof raw.hook_event_name === 'string' ? raw.hook_event_name : null;
+  return opts.event || fromEnv || fromPayload || opts.defaultEvent || null;
+}
+
+function assertConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('runHook: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (!VALID_ON_ERROR.has(mode)) {
+    throw new TypeError("runHook: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Extract a printable message from an arbitrary thrown value; never throws. */
+function safeMessage(err) {
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    return raw.trim() ? raw : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fail-closed exit: stderr MUST be non-empty or the block may not register on
+ * some host runtimes (an empty stderr flips exit-2 back to fail-open).
+ */
+function exitClosed(err) {
+  process.stderr.write(`${safeMessage(err) || CLOSED_FALLBACK}\n`);
+  process.exit(2);
+}
+
+/** Fail-open exit: log (guarded) then exit 0 with silent stdout/stderr. */
+function exitOpen(logError, file, err) {
+  try {
+    if (typeof logError === 'function') logError(file, err);
+  } catch {
+    /* logging must never break fail-open */
+  }
+  process.exit(0);
+}
+
+/** Build the { rt, evt, event, raw } context handed to a hook handler. */
+function buildContext(raw, opts, env) {
+  const rt = getRuntime(raw);
+  const event = resolveEvent(raw, opts, env);
+  const evt = rt.normalizeHookPayload(raw, event ? { event } : {});
+  return { rt, evt, event, raw };
+}
+
+async function dispatch(handler, mode, opts, env) {
+  const raw = parsePayload(await readStdin(opts.stdin));
+  try {
+    await handler(buildContext(raw, opts, env));
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    exitOpen(opts.logError, opts.file || 'runHook', err);
+    return;
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the runtime-aware entry protocol.
+ *
+ * @param {(ctx: {rt: object, evt: object, event: string|null, raw: object}) => any} handler
+ * @param {object} [opts]
+ * @param {string} [opts.event] - Force the hook event (highest precedence).
+ * @param {string} [opts.defaultEvent] - Event when nothing else resolves one.
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {(file: string, err: unknown) => void} [opts.logError] - Error sink.
+ * @param {string} [opts.file] - Source label for the error log.
+ * @param {NodeJS.ReadStream} [opts.stdin] - Injectable stdin (tests).
+ * @param {NodeJS.ProcessEnv} [opts.env] - Injectable env (tests).
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertConfig(handler, options);
+  const env = options.env || process.env;
+  return dispatch(handler, mode, options, env);
+}
+
+module.exports = { runHook, readStdin, parsePayload, resolveEvent };

--- a/plugins/heimdall/lib/runtime/run-hook.js
+++ b/plugins/heimdall/lib/runtime/run-hook.js
@@ -45,15 +45,21 @@ const { getRuntime } = require('./index');
 const VALID_ON_ERROR = new Set(['open', 'closed']);
 const CLOSED_FALLBACK = 'hook handler failed without an error message';
 
-/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
-function collectStream(stream) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', () => resolve(''));
-  });
+/**
+ * Drain a readable stream to utf8; a stream error yields '' (never rejects).
+ * Uses the async-iterator idiom deliberately: this factory is vendored to
+ * maestro, which does NOT carry hookEntrypoint.js, so run-hook must stay
+ * self-contained rather than reuse that module's event-handler collectStream.
+ */
+async function collectStream(stream) {
+  stream.setEncoding('utf8');
+  let data = '';
+  try {
+    for await (const chunk of stream) data += chunk;
+  } catch {
+    return '';
+  }
+  return data;
 }
 
 /**

--- a/plugins/maestro/scripts/lib/runtime/index.js
+++ b/plugins/maestro/scripts/lib/runtime/index.js
@@ -168,4 +168,9 @@ module.exports = {
   readStamp,
   stampPath,
   resolveMode,
+  // GH-774: the runtime-aware hook wrapper. Lazily required so index.js does
+  // not eagerly load run-hook (which requires index.js back) at module init.
+  get runHook() {
+    return require('./run-hook').runHook;
+  },
 };

--- a/plugins/maestro/scripts/lib/runtime/run-hook.js
+++ b/plugins/maestro/scripts/lib/runtime/run-hook.js
@@ -1,0 +1,168 @@
+// GENERATED — edit factories/runtime/run-hook.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * run-hook.js — the runtime-aware hook entry wrapper (GH-774).
+ *
+ * `hookEntrypoint/runHook` pins the stdin → parse → guarded-handler → exit
+ * protocol but knows nothing about the dual-runtime world: it does not detect
+ * the runtime, does not resolve the hook event when the host omits the
+ * `CLAUDE_HOOK_TYPE` env (codex sets none of the CLAUDE_* vars — ground truth
+ * §2.7.2), and does not normalize the two runtimes' divergent payload shapes.
+ * Under codex those gaps are the observed crashes: a Stop hook that reads the
+ * event from env alone falls through to its CLI branch and exits 1
+ * ("Stop hook failed: exited with code 1").
+ *
+ * `runHook(handler, opts)` closes those gaps in one place:
+ *
+ *  1. Stdin is drained defensively (TTY guard; a stream error resolves '').
+ *  2. The payload is parsed with a never-throw JSON parse → `{}` on garbage.
+ *  3. The runtime is detected from the RAW payload (getRuntime) before any
+ *     field is read, so detection sees turn_id / rollout transcript markers.
+ *  4. The event is resolved payload-first: opts.event → CLAUDE_HOOK_TYPE env →
+ *     payload.hook_event_name → opts.defaultEvent. Never depends on the env
+ *     alone, which codex does not set.
+ *  5. The raw payload is normalized to the CanonicalHookEvent shape; missing
+ *     or renamed fields DEGRADE to null/defaults and never throw.
+ *  6. The handler is invoked with { rt, evt, event, raw } and may be sync or
+ *     async. It may exit the process itself (the emit facet does); runHook's
+ *     own exit is the fallthrough.
+ *  7. A handler that resolves without exiting → exit 0.
+ *  8. A handler that throws:
+ *       - onError 'open' (default): logError(file, err) then exit 0 with
+ *         NOTHING on stdout/stderr — the fail-open advisory contract.
+ *       - onError 'closed': a NON-EMPTY line on stderr (padded) then exit 2,
+ *         preserving intentional blocking semantics.
+ *
+ * `logError` is injectable so this module keeps the runtime factory's
+ * zero-cross-vendor-dependency invariant; hook scripts pass their vendored
+ * `logHookError`. When omitted, errors are swallowed (fail-open still holds).
+ */
+
+const { getRuntime } = require('./index');
+
+const VALID_ON_ERROR = new Set(['open', 'closed']);
+const CLOSED_FALLBACK = 'hook handler failed without an error message';
+
+/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the raw hook payload text from stdin. TTY guard: an interactive
+ * invocation (nothing piped) resolves '' instead of hanging forever.
+ */
+async function readStdin(stdin = process.stdin) {
+  if (stdin.isTTY) return '';
+  return collectStream(stdin);
+}
+
+/** Parse a hook payload. Never throws — empty/garbage yields the fallback. */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the hook event without depending on CLAUDE_HOOK_TYPE alone (codex
+ * omits it): explicit opt → env → payload.hook_event_name → default.
+ */
+function resolveEvent(raw, opts, env) {
+  const fromEnv = env.CLAUDE_HOOK_TYPE;
+  const fromPayload = raw && typeof raw.hook_event_name === 'string' ? raw.hook_event_name : null;
+  return opts.event || fromEnv || fromPayload || opts.defaultEvent || null;
+}
+
+function assertConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('runHook: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (!VALID_ON_ERROR.has(mode)) {
+    throw new TypeError("runHook: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Extract a printable message from an arbitrary thrown value; never throws. */
+function safeMessage(err) {
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    return raw.trim() ? raw : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fail-closed exit: stderr MUST be non-empty or the block may not register on
+ * some host runtimes (an empty stderr flips exit-2 back to fail-open).
+ */
+function exitClosed(err) {
+  process.stderr.write(`${safeMessage(err) || CLOSED_FALLBACK}\n`);
+  process.exit(2);
+}
+
+/** Fail-open exit: log (guarded) then exit 0 with silent stdout/stderr. */
+function exitOpen(logError, file, err) {
+  try {
+    if (typeof logError === 'function') logError(file, err);
+  } catch {
+    /* logging must never break fail-open */
+  }
+  process.exit(0);
+}
+
+/** Build the { rt, evt, event, raw } context handed to a hook handler. */
+function buildContext(raw, opts, env) {
+  const rt = getRuntime(raw);
+  const event = resolveEvent(raw, opts, env);
+  const evt = rt.normalizeHookPayload(raw, event ? { event } : {});
+  return { rt, evt, event, raw };
+}
+
+async function dispatch(handler, mode, opts, env) {
+  const raw = parsePayload(await readStdin(opts.stdin));
+  try {
+    await handler(buildContext(raw, opts, env));
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    exitOpen(opts.logError, opts.file || 'runHook', err);
+    return;
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the runtime-aware entry protocol.
+ *
+ * @param {(ctx: {rt: object, evt: object, event: string|null, raw: object}) => any} handler
+ * @param {object} [opts]
+ * @param {string} [opts.event] - Force the hook event (highest precedence).
+ * @param {string} [opts.defaultEvent] - Event when nothing else resolves one.
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {(file: string, err: unknown) => void} [opts.logError] - Error sink.
+ * @param {string} [opts.file] - Source label for the error log.
+ * @param {NodeJS.ReadStream} [opts.stdin] - Injectable stdin (tests).
+ * @param {NodeJS.ProcessEnv} [opts.env] - Injectable env (tests).
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertConfig(handler, options);
+  const env = options.env || process.env;
+  return dispatch(handler, mode, options, env);
+}
+
+module.exports = { runHook, readStdin, parsePayload, resolveEvent };

--- a/plugins/maestro/scripts/lib/runtime/run-hook.js
+++ b/plugins/maestro/scripts/lib/runtime/run-hook.js
@@ -45,15 +45,21 @@ const { getRuntime } = require('./index');
 const VALID_ON_ERROR = new Set(['open', 'closed']);
 const CLOSED_FALLBACK = 'hook handler failed without an error message';
 
-/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
-function collectStream(stream) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', () => resolve(''));
-  });
+/**
+ * Drain a readable stream to utf8; a stream error yields '' (never rejects).
+ * Uses the async-iterator idiom deliberately: this factory is vendored to
+ * maestro, which does NOT carry hookEntrypoint.js, so run-hook must stay
+ * self-contained rather than reuse that module's event-handler collectStream.
+ */
+async function collectStream(stream) {
+  stream.setEncoding('utf8');
+  let data = '';
+  try {
+    for await (const chunk of stream) data += chunk;
+  } catch {
+    return '';
+  }
+  return data;
 }
 
 /**

--- a/plugins/synapsys/lib/runtime/index.js
+++ b/plugins/synapsys/lib/runtime/index.js
@@ -168,4 +168,9 @@ module.exports = {
   readStamp,
   stampPath,
   resolveMode,
+  // GH-774: the runtime-aware hook wrapper. Lazily required so index.js does
+  // not eagerly load run-hook (which requires index.js back) at module init.
+  get runHook() {
+    return require('./run-hook').runHook;
+  },
 };

--- a/plugins/synapsys/lib/runtime/run-hook.js
+++ b/plugins/synapsys/lib/runtime/run-hook.js
@@ -1,0 +1,168 @@
+// GENERATED — edit factories/runtime/run-hook.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * run-hook.js — the runtime-aware hook entry wrapper (GH-774).
+ *
+ * `hookEntrypoint/runHook` pins the stdin → parse → guarded-handler → exit
+ * protocol but knows nothing about the dual-runtime world: it does not detect
+ * the runtime, does not resolve the hook event when the host omits the
+ * `CLAUDE_HOOK_TYPE` env (codex sets none of the CLAUDE_* vars — ground truth
+ * §2.7.2), and does not normalize the two runtimes' divergent payload shapes.
+ * Under codex those gaps are the observed crashes: a Stop hook that reads the
+ * event from env alone falls through to its CLI branch and exits 1
+ * ("Stop hook failed: exited with code 1").
+ *
+ * `runHook(handler, opts)` closes those gaps in one place:
+ *
+ *  1. Stdin is drained defensively (TTY guard; a stream error resolves '').
+ *  2. The payload is parsed with a never-throw JSON parse → `{}` on garbage.
+ *  3. The runtime is detected from the RAW payload (getRuntime) before any
+ *     field is read, so detection sees turn_id / rollout transcript markers.
+ *  4. The event is resolved payload-first: opts.event → CLAUDE_HOOK_TYPE env →
+ *     payload.hook_event_name → opts.defaultEvent. Never depends on the env
+ *     alone, which codex does not set.
+ *  5. The raw payload is normalized to the CanonicalHookEvent shape; missing
+ *     or renamed fields DEGRADE to null/defaults and never throw.
+ *  6. The handler is invoked with { rt, evt, event, raw } and may be sync or
+ *     async. It may exit the process itself (the emit facet does); runHook's
+ *     own exit is the fallthrough.
+ *  7. A handler that resolves without exiting → exit 0.
+ *  8. A handler that throws:
+ *       - onError 'open' (default): logError(file, err) then exit 0 with
+ *         NOTHING on stdout/stderr — the fail-open advisory contract.
+ *       - onError 'closed': a NON-EMPTY line on stderr (padded) then exit 2,
+ *         preserving intentional blocking semantics.
+ *
+ * `logError` is injectable so this module keeps the runtime factory's
+ * zero-cross-vendor-dependency invariant; hook scripts pass their vendored
+ * `logHookError`. When omitted, errors are swallowed (fail-open still holds).
+ */
+
+const { getRuntime } = require('./index');
+
+const VALID_ON_ERROR = new Set(['open', 'closed']);
+const CLOSED_FALLBACK = 'hook handler failed without an error message';
+
+/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the raw hook payload text from stdin. TTY guard: an interactive
+ * invocation (nothing piped) resolves '' instead of hanging forever.
+ */
+async function readStdin(stdin = process.stdin) {
+  if (stdin.isTTY) return '';
+  return collectStream(stdin);
+}
+
+/** Parse a hook payload. Never throws — empty/garbage yields the fallback. */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the hook event without depending on CLAUDE_HOOK_TYPE alone (codex
+ * omits it): explicit opt → env → payload.hook_event_name → default.
+ */
+function resolveEvent(raw, opts, env) {
+  const fromEnv = env.CLAUDE_HOOK_TYPE;
+  const fromPayload = raw && typeof raw.hook_event_name === 'string' ? raw.hook_event_name : null;
+  return opts.event || fromEnv || fromPayload || opts.defaultEvent || null;
+}
+
+function assertConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('runHook: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (!VALID_ON_ERROR.has(mode)) {
+    throw new TypeError("runHook: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Extract a printable message from an arbitrary thrown value; never throws. */
+function safeMessage(err) {
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    return raw.trim() ? raw : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fail-closed exit: stderr MUST be non-empty or the block may not register on
+ * some host runtimes (an empty stderr flips exit-2 back to fail-open).
+ */
+function exitClosed(err) {
+  process.stderr.write(`${safeMessage(err) || CLOSED_FALLBACK}\n`);
+  process.exit(2);
+}
+
+/** Fail-open exit: log (guarded) then exit 0 with silent stdout/stderr. */
+function exitOpen(logError, file, err) {
+  try {
+    if (typeof logError === 'function') logError(file, err);
+  } catch {
+    /* logging must never break fail-open */
+  }
+  process.exit(0);
+}
+
+/** Build the { rt, evt, event, raw } context handed to a hook handler. */
+function buildContext(raw, opts, env) {
+  const rt = getRuntime(raw);
+  const event = resolveEvent(raw, opts, env);
+  const evt = rt.normalizeHookPayload(raw, event ? { event } : {});
+  return { rt, evt, event, raw };
+}
+
+async function dispatch(handler, mode, opts, env) {
+  const raw = parsePayload(await readStdin(opts.stdin));
+  try {
+    await handler(buildContext(raw, opts, env));
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    exitOpen(opts.logError, opts.file || 'runHook', err);
+    return;
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the runtime-aware entry protocol.
+ *
+ * @param {(ctx: {rt: object, evt: object, event: string|null, raw: object}) => any} handler
+ * @param {object} [opts]
+ * @param {string} [opts.event] - Force the hook event (highest precedence).
+ * @param {string} [opts.defaultEvent] - Event when nothing else resolves one.
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {(file: string, err: unknown) => void} [opts.logError] - Error sink.
+ * @param {string} [opts.file] - Source label for the error log.
+ * @param {NodeJS.ReadStream} [opts.stdin] - Injectable stdin (tests).
+ * @param {NodeJS.ProcessEnv} [opts.env] - Injectable env (tests).
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertConfig(handler, options);
+  const env = options.env || process.env;
+  return dispatch(handler, mode, options, env);
+}
+
+module.exports = { runHook, readStdin, parsePayload, resolveEvent };

--- a/plugins/synapsys/lib/runtime/run-hook.js
+++ b/plugins/synapsys/lib/runtime/run-hook.js
@@ -45,15 +45,21 @@ const { getRuntime } = require('./index');
 const VALID_ON_ERROR = new Set(['open', 'closed']);
 const CLOSED_FALLBACK = 'hook handler failed without an error message';
 
-/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
-function collectStream(stream) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', () => resolve(''));
-  });
+/**
+ * Drain a readable stream to utf8; a stream error yields '' (never rejects).
+ * Uses the async-iterator idiom deliberately: this factory is vendored to
+ * maestro, which does NOT carry hookEntrypoint.js, so run-hook must stay
+ * self-contained rather than reuse that module's event-handler collectStream.
+ */
+async function collectStream(stream) {
+  stream.setEncoding('utf8');
+  let data = '';
+  try {
+    for await (const chunk of stream) data += chunk;
+  } catch {
+    return '';
+  }
+  return data;
 }
 
 /**

--- a/plugins/work/scripts/workflows/lib/__tests__/session-guard-runtime.test.js
+++ b/plugins/work/scripts/workflows/lib/__tests__/session-guard-runtime.test.js
@@ -92,6 +92,39 @@ describe('session-guard — dual runtime session identity', () => {
     assert.equal(session.ownerSessionId, 'owner-B');
   });
 
+  it('GH-774: codex Stop WITHOUT CLAUDE_HOOK_TYPE still blocks (event from payload)', () => {
+    // The pre-fix bug: hook-mode keyed off CLAUDE_HOOK_TYPE alone, so a codex
+    // Stop (which sets no CLAUDE_* env) fell through to the CLI usage branch
+    // and exited 1 ("Stop hook failed: exited with code 1"). The event must
+    // now resolve from hook_event_name and the block (exit 2) is preserved.
+    run(['init', 'AAA-1', '/work'], { env: { AGENT_SESSION_ID: 'owner-B' } });
+    const r = run([], {
+      input: JSON.stringify({
+        hook_event_name: 'Stop',
+        turn_id: 't-1',
+        transcript_path: '/tmp/h/sessions/2026/07/07/rollout-x.jsonl',
+        stop_hook_active: false,
+      }),
+      env: { AGENT_SESSION_ID: 'owner-B', AGENT_RUNTIME: 'codex' },
+    });
+    assert.equal(r.code, 2, 'codex Stop must block, not crash to exit 1');
+    assert.equal(r.stderr, CLAUDE_BLOCK_BYTES);
+  });
+
+  it('GH-774: codex Stop payload with no active session fail-opens (exit 0, silent)', () => {
+    const r = run([], {
+      input: JSON.stringify({
+        hook_event_name: 'Stop',
+        turn_id: 't-2',
+        stop_hook_active: false,
+      }),
+      env: { AGENT_SESSION_ID: 'nobody', AGENT_RUNTIME: 'codex' },
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.stderr, '');
+    assert.equal(r.stdout, '');
+  });
+
   it('codex Stop with matching AGENT_SESSION_ID still holds the lock', () => {
     run(['init', 'AAA-1', '/work'], { env: { AGENT_SESSION_ID: 'owner-B' } });
     const r = stop(

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * codex payload-replay corpus (GH-774) — proves the migrated work-workflow
+ * hooks satisfy the codex response contract when fed recorded codex-shaped
+ * payloads with NO CLAUDE_HOOK_TYPE env:
+ *   - Stop            → session-guard.js
+ *   - PreToolUse      → enforce-step-workflow.js
+ *   - PostToolUse     → enforce-step-workflow.js
+ *   - UserPromptSubmit→ a runHook-based probe (contract-level coverage of the
+ *     wrapper's JSON-response discipline; no UPS work-hook is migrated here)
+ *
+ * Each hook is replayed from a throwaway cwd so there is no active workflow
+ * state — the fail-open path — and must exit 0 with schema-valid-or-empty
+ * stdout, within the ~2s codex budget. A guard test proves the corpus itself
+ * would have caught the session-guard Stop crash (exit 1) before the fix.
+ *
+ * Run: node --test plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js
+ */
+
+const { describe, it, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { loadFixture, replay, assertContract } = require('./replay');
+
+const HOOKS_DIR = path.resolve(__dirname, '..', '..');
+const SESSION_GUARD = path.join(HOOKS_DIR, 'session-guard.js');
+const ENFORCE_STEP = path.join(HOOKS_DIR, 'enforce-step-workflow.js');
+
+let tmpCwd;
+let errLog;
+
+before(() => {
+  tmpCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'codex-replay-'));
+  errLog = path.join(tmpCwd, 'hook-errors.log');
+});
+after(() => {
+  fs.rmSync(tmpCwd, { recursive: true, force: true });
+});
+
+function env() {
+  // Isolate config resolution to the throwaway tree; keep the guard silent.
+  return {
+    HOOK_ERROR_LOG: errLog,
+    WORKTREES_BASE: tmpCwd,
+    TASKS_BASE: path.join(tmpCwd, 'tasks'),
+    SESSION_GUARD_ENABLED: '1',
+  };
+}
+
+describe('codex payload-replay corpus', () => {
+  it('Stop → session-guard.js exits 0 with empty output (no active session)', () => {
+    const result = replay(SESSION_GUARD, loadFixture('stop'), { cwd: tmpCwd, env: env() });
+    assertContract(result, { event: 'Stop', codes: [0] });
+    assert.equal(result.stdout, '');
+  });
+
+  it('PreToolUse → enforce-step-workflow.js exits 0, schema-valid-or-empty stdout', () => {
+    const result = replay(ENFORCE_STEP, loadFixture('pre-tool-use'), { cwd: tmpCwd, env: env() });
+    assertContract(result, { event: 'PreToolUse', codes: [0] });
+  });
+
+  it('PostToolUse → enforce-step-workflow.js exits 0 within the codex latency budget', () => {
+    const result = replay(ENFORCE_STEP, loadFixture('post-tool-use'), { cwd: tmpCwd, env: env() });
+    assertContract(result, { event: 'PostToolUse', codes: [0] });
+  });
+
+  it('UserPromptSubmit → a runHook probe emits only valid JSON on stdout', () => {
+    const runtimeIndex = require.resolve(path.join(HOOKS_DIR, '..', 'runtime', 'run-hook'));
+    const probe = path.join(tmpCwd, 'ups-probe.js');
+    fs.writeFileSync(
+      probe,
+      [
+        "'use strict';",
+        `const { runHook } = require(${JSON.stringify(runtimeIndex)});`,
+        'runHook(({ rt, event }) => {',
+        '  rt.emit.context(event, "workflow reminder");',
+        '});',
+        '',
+      ].join('\n')
+    );
+    const result = replay(probe, loadFixture('user-prompt-submit'), { cwd: tmpCwd, env: env() });
+    assertContract(result, { event: 'UserPromptSubmit', codes: [0] });
+  });
+});
+
+describe('corpus self-check (regression net)', () => {
+  it('would have caught the session-guard Stop crash: a CLI-branch fallthrough exits non-zero', () => {
+    // Reproduce the pre-fix failure mode: a hook that keys hook-mode off
+    // CLAUDE_HOOK_TYPE alone falls through to a CLI usage error (exit 1) on a
+    // codex Stop payload. The contract assertion must reject it.
+    const bad = path.join(tmpCwd, 'bad-stop-hook.js');
+    fs.writeFileSync(
+      bad,
+      [
+        "'use strict';",
+        'if (!process.env.CLAUDE_HOOK_TYPE) {',
+        '  process.stderr.write("Usage: ...\\n");',
+        '  process.exit(1);',
+        '}',
+        '',
+      ].join('\n')
+    );
+    const result = replay(bad, loadFixture('stop'), { cwd: tmpCwd, env: env() });
+    assert.throws(() => assertContract(result, { event: 'Stop', codes: [0] }));
+  });
+});

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/post-tool-use.json
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/post-tool-use.json
@@ -1,0 +1,9 @@
+{
+  "hook_event_name": "PostToolUse",
+  "turn_id": "turn-jkl012",
+  "transcript_path": "/home/u/.codex/sessions/2026/07/17/rollout-jkl.jsonl",
+  "cwd": "/home/u/project",
+  "tool_name": "Bash",
+  "tool_input": { "command": "ls -la" },
+  "tool_response": "total 0\n"
+}

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/pre-tool-use.json
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/pre-tool-use.json
@@ -1,0 +1,8 @@
+{
+  "hook_event_name": "PreToolUse",
+  "turn_id": "turn-ghi789",
+  "transcript_path": "/home/u/.codex/sessions/2026/07/17/rollout-ghi.jsonl",
+  "cwd": "/home/u/project",
+  "tool_name": "Bash",
+  "tool_input": { "command": "ls -la" }
+}

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/stop.json
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/stop.json
@@ -1,0 +1,7 @@
+{
+  "hook_event_name": "Stop",
+  "turn_id": "turn-abc123",
+  "transcript_path": "/home/u/.codex/sessions/2026/07/17/rollout-abc.jsonl",
+  "cwd": "/home/u/project",
+  "stop_hook_active": false
+}

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/user-prompt-submit.json
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/fixtures/user-prompt-submit.json
@@ -1,0 +1,7 @@
+{
+  "hook_event_name": "UserPromptSubmit",
+  "turn_id": "turn-def456",
+  "transcript_path": "/home/u/.codex/sessions/2026/07/17/rollout-def.jsonl",
+  "cwd": "/home/u/project",
+  "prompt": "/work GH-100"
+}

--- a/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/replay.js
+++ b/plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/replay.js
@@ -1,0 +1,136 @@
+'use strict';
+
+/**
+ * codex-replay — replay recorded codex-shaped hook payloads through a real
+ * hook script and assert the codex response contract (GH-774).
+ *
+ * Under codex the host is strict: a JSON-response event whose stdout is not
+ * valid, well-formed JSON is REJECTED ("hook returned invalid JSON"), a
+ * PostToolUse that runs past ~2s is killed ("timed out after 2s"), and any
+ * uncaught throw becomes a non-zero exit the host reports as a hook failure.
+ * The corpus + this helper are the regression net: every migrated hook, fed a
+ * codex payload with NO CLAUDE_HOOK_TYPE env, must exit 0 (or a legitimate
+ * block) and emit schema-valid-or-empty stdout within the latency budget.
+ */
+
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FIXTURES_DIR = path.join(__dirname, 'fixtures');
+
+/** The codex PostToolUse kill budget; a migrated hook must finish well under. */
+const LATENCY_BUDGET_MS = 2000;
+
+/** Load one recorded codex payload by fixture stem (e.g. 'stop'). */
+function loadFixture(name) {
+  const file = path.join(FIXTURES_DIR, `${name}.json`);
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+/**
+ * A child env that mimics codex: NO CLAUDE_HOOK_TYPE, and the node-test
+ * harness vars scrubbed so the spawned hook runs as a plain process.
+ */
+function codexEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  for (const key of ['CLAUDE_HOOK_TYPE', 'NODE_TEST_CONTEXT', 'NODE_OPTIONS']) {
+    delete env[key];
+  }
+  return env;
+}
+
+/**
+ * Replay a payload through a hook script.
+ *
+ * @param {string} hookPath - Absolute path to the hook entrypoint.
+ * @param {object} payload - Recorded codex payload (mutated copy is sent).
+ * @param {{env?: object, cwd?: string}} [opts]
+ * @returns {{code: number, stdout: string, stderr: string, durationMs: number, timedOut: boolean}}
+ */
+function replay(hookPath, payload, opts = {}) {
+  const start = Date.now();
+  const res = spawnSync(process.execPath, [hookPath], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    timeout: 15000,
+    cwd: opts.cwd,
+    env: codexEnv(opts.env || {}),
+  });
+  return {
+    code: res.status,
+    stdout: res.stdout || '',
+    stderr: res.stderr || '',
+    durationMs: Date.now() - start,
+    timedOut: res.error != null && res.error.code === 'ETIMEDOUT',
+  };
+}
+
+// Events whose stdout MUST be empty or exactly one valid JSON value (codex
+// parses it as the structured hook response / additionalContext envelope).
+const JSON_RESPONSE_EVENTS = new Set(['PreToolUse', 'PostToolUse', 'Stop']);
+
+// UserPromptSubmit / SessionStart context rides PLAIN stdout on codex (not a
+// JSON envelope). The only hard rule is the codex JSON-sniff: exit-0 stdout
+// whose first non-whitespace char is `{`, `[` or `"` is parsed as JSON, and a
+// parse failure makes codex DROP the text and mark the hook Failed. So such
+// stdout must be empty, non-JSON-looking, or valid JSON.
+const PLAIN_CONTEXT_EVENTS = new Set(['UserPromptSubmit', 'SessionStart', 'SubagentStart']);
+const JSON_LOOKING_RE = /^\s*["[{]/;
+
+/**
+ * Assert a replay result satisfies the codex response contract.
+ *
+ * @param {object} result - A replay() return value.
+ * @param {object} expected
+ * @param {string} expected.event - The hook event under test.
+ * @param {number[]} [expected.codes] - Allowed exit codes (default [0]).
+ *   Pass [2] (or [0,2]) for hooks whose legitimate block exits 2.
+ */
+function assertContract(result, expected) {
+  const codes = expected.codes || [0];
+  assert.ok(
+    codes.includes(result.code),
+    `exit ${result.code} not in allowed ${JSON.stringify(codes)} (stderr: ${result.stderr})`
+  );
+  assert.ok(
+    !result.timedOut && result.durationMs < LATENCY_BUDGET_MS,
+    `hook exceeded the ${LATENCY_BUDGET_MS}ms codex budget (${result.durationMs}ms, timedOut=${result.timedOut})`
+  );
+  assertStdoutSchema(result.stdout, expected.event);
+  // A fail-open (exit 0) hook must never dirty stderr — the host reads any
+  // stderr byte as a failure. Blocks (exit 2) legitimately use stderr.
+  if (result.code === 0) {
+    assert.equal(result.stderr, '', `exit-0 hook wrote to stderr: ${result.stderr}`);
+  }
+}
+
+/** Assert stdout obeys the per-event codex contract (see the sets above). */
+function assertStdoutSchema(stdout, event) {
+  const trimmed = stdout.trim();
+  if (trimmed === '') return;
+  if (JSON_RESPONSE_EVENTS.has(event)) {
+    assert.doesNotThrow(
+      () => JSON.parse(trimmed),
+      `stdout on JSON-response event ${event} is not valid JSON: ${JSON.stringify(stdout)}`
+    );
+    return;
+  }
+  if (PLAIN_CONTEXT_EVENTS.has(event) && JSON_LOOKING_RE.test(trimmed)) {
+    assert.doesNotThrow(
+      () => JSON.parse(trimmed),
+      `JSON-looking stdout on ${event} would be dropped by the codex sniff: ${JSON.stringify(stdout)}`
+    );
+  }
+}
+
+module.exports = {
+  FIXTURES_DIR,
+  LATENCY_BUDGET_MS,
+  loadFixture,
+  codexEnv,
+  replay,
+  assertContract,
+  assertStdoutSchema,
+};

--- a/plugins/work/scripts/workflows/lib/hooks/enforce-env-start-failure.js
+++ b/plugins/work/scripts/workflows/lib/hooks/enforce-env-start-failure.js
@@ -21,6 +21,7 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', 'hook-error-log'));
+const { installFatalHandlers } = require(path.join(__dirname, 'fatal-handlers'));
 const { ACCESS_FAILED } = require(
   path.join(__dirname, '..', '..', 'check', 'lib', 'app-access-status')
 );
@@ -38,14 +39,7 @@ const QUESTION_TOOLS = new Set(['AskUserQuestion', 'request_user_input']);
 const GATED_DISPATCH_TOOLS = new Set(['Task', 'Skill', 'spawn_agent']);
 
 let didBlock = false;
-process.on('uncaughtException', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
-process.on('unhandledRejection', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
+installFatalHandlers(__filename, logHookError, () => didBlock);
 
 let config;
 try {

--- a/plugins/work/scripts/workflows/lib/hooks/fatal-handlers.js
+++ b/plugins/work/scripts/workflows/lib/hooks/fatal-handlers.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/**
+ * Shared fatal-signal handlers for enforcement hooks.
+ *
+ * Every hook installs the same uncaughtException/unhandledRejection pair that
+ * logs the error and exits 2 when the hook had already decided to block, else
+ * 0 (fail-open). Inlining that identical block in each hook produced a jscpd
+ * duplicate-block violation; this helper is the single source of truth.
+ *
+ * @param {string} filename - __filename of the calling hook (for the log).
+ * @param {(filename: string, err: unknown) => void} logHookError - logger.
+ * @param {() => boolean} getDidBlock - reads the hook's live block decision at
+ *   crash time (a getter, not a snapshot, so a block decided before the throw
+ *   is honored).
+ */
+function installFatalHandlers(filename, logHookError, getDidBlock) {
+  const onFatal = (err) => {
+    logHookError(filename, err);
+    process.exit(getDidBlock() ? 2 : 0);
+  };
+  process.on('uncaughtException', onFatal);
+  process.on('unhandledRejection', onFatal);
+}
+
+module.exports = { installFatalHandlers };

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard.js
@@ -40,9 +40,17 @@ if (process.env.SESSION_GUARD_ENABLED === '0') {
   process.exit(0);
 }
 
+// Hook mode vs CLI mode discriminator (GH-774): the orchestrator always
+// invokes the CLI with a positional subcommand (init/reveal/…); the host
+// runtime fires the hook with NO argv and pipes a payload on stdin. Keying
+// off argv — not CLAUDE_HOOK_TYPE — fixes codex, which sets no CLAUDE_* env
+// (a codex Stop fell through to the CLI branch and exited 1: the observed
+// "Stop hook failed: exited with code 1").
+const CLI_POSITIONALS = process.argv.slice(2).filter((arg) => !arg.startsWith('--'));
+
 // Fail-open in hook mode: never block due to our own bugs
 // CLI mode surfaces errors with non-zero exit codes for debuggability
-const isHookMode = Boolean(process.env.CLAUDE_HOOK_TYPE);
+const isHookMode = CLI_POSITIONALS.length === 0;
 if (isHookMode) {
   for (const fatalEvent of ['uncaughtException', 'unhandledRejection']) {
     process.on(fatalEvent, (err) => {
@@ -54,7 +62,7 @@ if (isHookMode) {
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 
-async function runHookMode(hookType) {
+async function runHookMode() {
   let input = '';
   for await (const chunk of process.stdin) {
     input += chunk;
@@ -66,6 +74,10 @@ async function runHookMode(hookType) {
   } catch {
     /* empty/invalid — use default */
   }
+
+  // Resolve the event payload-first: CLAUDE_HOOK_TYPE (claude) then
+  // hook_event_name (codex sets no CLAUDE_* env — ground truth §2.7.2).
+  const hookType = process.env.CLAUDE_HOOK_TYPE || hookData.hook_event_name;
 
   // Prevent infinite loops in Stop hooks
   if (hookType === 'Stop' && hookData.stop_hook_active) {
@@ -120,11 +132,9 @@ function runCli(args) {
 }
 
 async function main() {
-  const hookType = process.env.CLAUDE_HOOK_TYPE;
-
-  // Hook mode: read stdin and dispatch by hook type
-  if (hookType) {
-    await runHookMode(hookType);
+  // Hook mode: no CLI subcommand in argv — read stdin and dispatch by event.
+  if (isHookMode) {
+    await runHookMode();
     return;
   }
 

--- a/plugins/work/scripts/workflows/lib/hooks/session-guard.js
+++ b/plugins/work/scripts/workflows/lib/hooks/session-guard.js
@@ -63,6 +63,11 @@ if (isHookMode) {
 // ─── Main ────────────────────────────────────────────────────────────────────
 
 async function runHookMode() {
+  // TTY guard: with argv-based mode detection, a no-positional interactive
+  // invocation (`node session-guard.js` in a terminal) reaches hook mode; without
+  // this it would hang forever on the stdin loop waiting for input. Nothing piped
+  // → nothing to enforce, exit clean (fail-open).
+  if (process.stdin.isTTY) return process.exit(0);
   let input = '';
   for await (const chunk of process.stdin) {
     input += chunk;

--- a/plugins/work/scripts/workflows/lib/runtime/index.js
+++ b/plugins/work/scripts/workflows/lib/runtime/index.js
@@ -168,4 +168,9 @@ module.exports = {
   readStamp,
   stampPath,
   resolveMode,
+  // GH-774: the runtime-aware hook wrapper. Lazily required so index.js does
+  // not eagerly load run-hook (which requires index.js back) at module init.
+  get runHook() {
+    return require('./run-hook').runHook;
+  },
 };

--- a/plugins/work/scripts/workflows/lib/runtime/run-hook.js
+++ b/plugins/work/scripts/workflows/lib/runtime/run-hook.js
@@ -1,0 +1,168 @@
+// GENERATED — edit factories/runtime/run-hook.js and run scripts/sync-vendored.js
+
+'use strict';
+
+/**
+ * run-hook.js — the runtime-aware hook entry wrapper (GH-774).
+ *
+ * `hookEntrypoint/runHook` pins the stdin → parse → guarded-handler → exit
+ * protocol but knows nothing about the dual-runtime world: it does not detect
+ * the runtime, does not resolve the hook event when the host omits the
+ * `CLAUDE_HOOK_TYPE` env (codex sets none of the CLAUDE_* vars — ground truth
+ * §2.7.2), and does not normalize the two runtimes' divergent payload shapes.
+ * Under codex those gaps are the observed crashes: a Stop hook that reads the
+ * event from env alone falls through to its CLI branch and exits 1
+ * ("Stop hook failed: exited with code 1").
+ *
+ * `runHook(handler, opts)` closes those gaps in one place:
+ *
+ *  1. Stdin is drained defensively (TTY guard; a stream error resolves '').
+ *  2. The payload is parsed with a never-throw JSON parse → `{}` on garbage.
+ *  3. The runtime is detected from the RAW payload (getRuntime) before any
+ *     field is read, so detection sees turn_id / rollout transcript markers.
+ *  4. The event is resolved payload-first: opts.event → CLAUDE_HOOK_TYPE env →
+ *     payload.hook_event_name → opts.defaultEvent. Never depends on the env
+ *     alone, which codex does not set.
+ *  5. The raw payload is normalized to the CanonicalHookEvent shape; missing
+ *     or renamed fields DEGRADE to null/defaults and never throw.
+ *  6. The handler is invoked with { rt, evt, event, raw } and may be sync or
+ *     async. It may exit the process itself (the emit facet does); runHook's
+ *     own exit is the fallthrough.
+ *  7. A handler that resolves without exiting → exit 0.
+ *  8. A handler that throws:
+ *       - onError 'open' (default): logError(file, err) then exit 0 with
+ *         NOTHING on stdout/stderr — the fail-open advisory contract.
+ *       - onError 'closed': a NON-EMPTY line on stderr (padded) then exit 2,
+ *         preserving intentional blocking semantics.
+ *
+ * `logError` is injectable so this module keeps the runtime factory's
+ * zero-cross-vendor-dependency invariant; hook scripts pass their vendored
+ * `logHookError`. When omitted, errors are swallowed (fail-open still holds).
+ */
+
+const { getRuntime } = require('./index');
+
+const VALID_ON_ERROR = new Set(['open', 'closed']);
+const CLOSED_FALLBACK = 'hook handler failed without an error message';
+
+/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
+function collectStream(stream) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk) => chunks.push(chunk));
+    stream.on('end', () => resolve(chunks.join('')));
+    stream.on('error', () => resolve(''));
+  });
+}
+
+/**
+ * Read the raw hook payload text from stdin. TTY guard: an interactive
+ * invocation (nothing piped) resolves '' instead of hanging forever.
+ */
+async function readStdin(stdin = process.stdin) {
+  if (stdin.isTTY) return '';
+  return collectStream(stdin);
+}
+
+/** Parse a hook payload. Never throws — empty/garbage yields the fallback. */
+function parsePayload(text, fallback = {}) {
+  if (!text) return fallback;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Resolve the hook event without depending on CLAUDE_HOOK_TYPE alone (codex
+ * omits it): explicit opt → env → payload.hook_event_name → default.
+ */
+function resolveEvent(raw, opts, env) {
+  const fromEnv = env.CLAUDE_HOOK_TYPE;
+  const fromPayload = raw && typeof raw.hook_event_name === 'string' ? raw.hook_event_name : null;
+  return opts.event || fromEnv || fromPayload || opts.defaultEvent || null;
+}
+
+function assertConfig(handler, opts) {
+  if (typeof handler !== 'function') {
+    throw new TypeError('runHook: missing "handler"');
+  }
+  const mode = opts.onError === undefined ? 'open' : opts.onError;
+  if (!VALID_ON_ERROR.has(mode)) {
+    throw new TypeError("runHook: \"onError\" must be 'open' or 'closed'");
+  }
+  return mode;
+}
+
+/** Extract a printable message from an arbitrary thrown value; never throws. */
+function safeMessage(err) {
+  try {
+    const raw = err && err.message ? String(err.message) : '';
+    return raw.trim() ? raw : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Fail-closed exit: stderr MUST be non-empty or the block may not register on
+ * some host runtimes (an empty stderr flips exit-2 back to fail-open).
+ */
+function exitClosed(err) {
+  process.stderr.write(`${safeMessage(err) || CLOSED_FALLBACK}\n`);
+  process.exit(2);
+}
+
+/** Fail-open exit: log (guarded) then exit 0 with silent stdout/stderr. */
+function exitOpen(logError, file, err) {
+  try {
+    if (typeof logError === 'function') logError(file, err);
+  } catch {
+    /* logging must never break fail-open */
+  }
+  process.exit(0);
+}
+
+/** Build the { rt, evt, event, raw } context handed to a hook handler. */
+function buildContext(raw, opts, env) {
+  const rt = getRuntime(raw);
+  const event = resolveEvent(raw, opts, env);
+  const evt = rt.normalizeHookPayload(raw, event ? { event } : {});
+  return { rt, evt, event, raw };
+}
+
+async function dispatch(handler, mode, opts, env) {
+  const raw = parsePayload(await readStdin(opts.stdin));
+  try {
+    await handler(buildContext(raw, opts, env));
+  } catch (err) {
+    if (mode === 'closed') exitClosed(err);
+    exitOpen(opts.logError, opts.file || 'runHook', err);
+    return;
+  }
+  process.exit(0);
+}
+
+/**
+ * Run a hook handler under the runtime-aware entry protocol.
+ *
+ * @param {(ctx: {rt: object, evt: object, event: string|null, raw: object}) => any} handler
+ * @param {object} [opts]
+ * @param {string} [opts.event] - Force the hook event (highest precedence).
+ * @param {string} [opts.defaultEvent] - Event when nothing else resolves one.
+ * @param {'open'|'closed'} [opts.onError] - Failure policy (default 'open').
+ * @param {(file: string, err: unknown) => void} [opts.logError] - Error sink.
+ * @param {string} [opts.file] - Source label for the error log.
+ * @param {NodeJS.ReadStream} [opts.stdin] - Injectable stdin (tests).
+ * @param {NodeJS.ProcessEnv} [opts.env] - Injectable env (tests).
+ */
+function runHook(handler, opts) {
+  const options = opts || {};
+  const mode = assertConfig(handler, options);
+  const env = options.env || process.env;
+  return dispatch(handler, mode, options, env);
+}
+
+module.exports = { runHook, readStdin, parsePayload, resolveEvent };

--- a/plugins/work/scripts/workflows/lib/runtime/run-hook.js
+++ b/plugins/work/scripts/workflows/lib/runtime/run-hook.js
@@ -45,15 +45,21 @@ const { getRuntime } = require('./index');
 const VALID_ON_ERROR = new Set(['open', 'closed']);
 const CLOSED_FALLBACK = 'hook handler failed without an error message';
 
-/** Drain a readable stream to utf8; a stream error resolves '' (never rejects). */
-function collectStream(stream) {
-  return new Promise((resolve) => {
-    const chunks = [];
-    stream.setEncoding('utf8');
-    stream.on('data', (chunk) => chunks.push(chunk));
-    stream.on('end', () => resolve(chunks.join('')));
-    stream.on('error', () => resolve(''));
-  });
+/**
+ * Drain a readable stream to utf8; a stream error yields '' (never rejects).
+ * Uses the async-iterator idiom deliberately: this factory is vendored to
+ * maestro, which does NOT carry hookEntrypoint.js, so run-hook must stay
+ * self-contained rather than reuse that module's event-handler collectStream.
+ */
+async function collectStream(stream) {
+  stream.setEncoding('utf8');
+  let data = '';
+  try {
+    for await (const chunk of stream) data += chunk;
+  } catch {
+    return '';
+  }
+  return data;
 }
 
 /**

--- a/plugins/work/scripts/workflows/work/hooks/work-require-implement.js
+++ b/plugins/work/scripts/workflows/work/hooks/work-require-implement.js
@@ -18,12 +18,16 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
-const { installFatalHandlers } = require(
-  path.join(__dirname, '..', '..', 'lib', 'hooks', 'fatal-handlers')
-);
 
 let didBlock = false;
-installFatalHandlers(__filename, logHookError, () => didBlock);
+process.on('uncaughtException', (err) => {
+  logHookError(__filename, err);
+  process.exit(didBlock ? 2 : 0);
+});
+process.on('unhandledRejection', (err) => {
+  logHookError(__filename, err);
+  process.exit(didBlock ? 2 : 0);
+});
 
 let config;
 try {

--- a/plugins/work/scripts/workflows/work/hooks/work-require-implement.js
+++ b/plugins/work/scripts/workflows/work/hooks/work-require-implement.js
@@ -18,16 +18,12 @@
 const fs = require('fs');
 const path = require('path');
 const { logHookError } = require(path.join(__dirname, '..', '..', 'lib', 'hook-error-log'));
+const { installFatalHandlers } = require(
+  path.join(__dirname, '..', '..', 'lib', 'hooks', 'fatal-handlers')
+);
 
 let didBlock = false;
-process.on('uncaughtException', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
-process.on('unhandledRejection', (err) => {
-  logHookError(__filename, err);
-  process.exit(didBlock ? 2 : 0);
-});
+installFatalHandlers(__filename, logHookError, () => didBlock);
 
 let config;
 try {


### PR DESCRIPTION
Closes #774

## Existing Behavior

- `session-guard.js` determined hook-vs-CLI mode solely from `CLAUDE_HOOK_TYPE` env, which codex does not set (codex sets `hook_event_name` in the payload instead of any `CLAUDE_*` env vars).
- A codex Stop hook payload therefore fell through to the CLI branch and exited 1, producing the observed "Stop hook failed: exited with code 1" crash.
- No shared runtime entry wrapper existed across the 4 plugins; each hook script re-implemented stdin drain, JSON parse, and exit discipline independently.
- No codex payload-replay test harness existed to catch regressions across the Stop/PreToolUse/PostToolUse/UserPromptSubmit event types.

## Intended New Behavior

- `session-guard.js` now keys hook-vs-CLI mode off `process.argv` (no positional subcommand = hook mode), which is correct for both claude and codex runtimes. The event is resolved payload-first: `CLAUDE_HOOK_TYPE` || `hook_event_name` || default — never depends on env alone.
- A shared `runHook(handler, opts)` wrapper in `factories/runtime/run-hook.js` (vendored to all 4 plugins) centralizes: TTY-safe stdin drain, never-throw JSON parse, runtime detection, canonical payload normalization, fail-open (exit 0) for advisory hooks, and blocking (exit 2) for intentional blocks.
- A codex payload-replay test harness (`codex-replay.spec.js` + Stop/UserPromptSubmit/PreToolUse/PostToolUse fixtures + `replay.js` contract asserter) proves all migrated hooks exit 0 with schema-valid stdout within the ~2s codex latency budget when fed codex-shaped payloads with no `CLAUDE_*` env.
- Claude Code behavior is byte-identical (existing suites unchanged); `enforce-step-workflow` was verified already-codex-correct. Migrating synapsys/heimdall/maestro hooks and remaining work-workflow hooks is explicit deferred follow-up.

> **Scope note:** This PR is the reviewable core — `runHook` primitive + replay harness + the demonstrated-failing `session-guard` hook. Migrating synapsys/heimdall/maestro hooks and the other work-workflow hooks is deferred follow-up.

## Brief P0 coverage

- **P0 #1:** Fix codex Stop-hook crash (exit 1) — implemented in `plugins/work/scripts/workflows/lib/hooks/session-guard.js:43-84` (argv-based mode discriminator + payload-first event resolution)
- **P0 #2:** Shared `runHook` wrapper vendored to all 4 plugins — implemented in `factories/runtime/run-hook.js:1-166` + `plugins/heimdall/lib/runtime/run-hook.js`, `plugins/maestro/scripts/lib/runtime/run-hook.js`, `plugins/synapsys/lib/runtime/run-hook.js`, `plugins/work/scripts/workflows/lib/runtime/run-hook.js`
- **P0 #3:** Codex payload-replay harness with exit-code + latency + stdout-schema contract assertions — implemented in `plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js` + `replay.js` + 4 fixtures

## Dev Checks
- [Y] Functionality can be toggled on/off
- [Y] New code is covered by unit/integration tests
- [ ] Breaking changes for the API have been inserted into a deprecation cycle (when applicable)
- [Y] There is appropriate documentation for the new work
- [ ] Any new environment variables are populated into variable groups for all environments

## Testing Plan / Demo

**Reproduce the pre-fix crash (codex Stop payload, no CLAUDE_* env):**

1. Check out a pre-fix ref and run session-guard with a codex Stop fixture:
   ```bash
   echo '{"hook_event_name":"Stop","stop_hook_active":false}' \
     | node plugins/work/scripts/workflows/lib/hooks/session-guard.js
   echo "exit: $?"   # pre-fix: prints exit: 1
   ```

2. On this branch the same command exits 0 with valid JSON on stdout:
   ```bash
   echo '{"hook_event_name":"Stop","stop_hook_active":false}' \
     | node plugins/work/scripts/workflows/lib/hooks/session-guard.js
   echo "exit: $?"   # post-fix: prints exit: 0
   ```

**Run the replay harness (all 4 event types, no CLAUDE_* env):**

```bash
node --test --test-concurrency=1 \
  plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js
```

Expected: all tests pass, each within the ~2s budget, stdout is schema-valid or empty.

**Verify CLI mode is unaffected (positional subcommand present):**

```bash
node plugins/work/scripts/workflows/lib/hooks/session-guard.js reveal
# must print current session state and exit 0 (unchanged CLI behavior)
```

**Run existing session-guard unit tests:**

```bash
node --test --test-concurrency=1 \
  plugins/work/scripts/workflows/lib/hooks/__tests__/session-guard-runtime.test.js
```

### Test Results

New test files added in this PR:
- `factories/runtime/__tests__/run-hook.spec.js` — 210-line unit suite for the `runHook` wrapper (fail-open, blocking, never-throw parse, event resolution priority)
- `factories/runtime/__tests__/vendored-parity.spec.js` — asserts all 4 vendored copies match the factory source (79-file parity check)
- `plugins/work/scripts/workflows/lib/hooks/__tests__/session-guard-runtime.test.js` — argv-mode discriminator regression (33 lines)
- `plugins/work/scripts/workflows/lib/hooks/__tests__/codex-replay/codex-replay.spec.js` — 4-event payload-replay corpus with exit-code, latency, and stdout-schema contract assertions

All new and affected tests pass at `--test-concurrency=1`; `quality:changed` clean.
