### PR TITLE
fix(ghostwriter): inspect the bylines git imports, and stop clearing what cannot be read

### DIFF
--- a/plugins/ghostwriter/README.md
+++ b/plugins/ghostwriter/README.md
@@ -90,7 +90,23 @@ This is not a gap that can be closed by better parsing — evaluating those woul
 
 **The `commit-msg` hook is the layer that closes this.** Git hands it the final message, after every expansion, so it sees exactly what would be committed. If you want the guarantee to hold against evasion rather than accident, run `/ghostwriter:install` — the PreToolUse hook gives fast feedback at the point of the mistake, and the git hook is the backstop that cannot be talked around.
 
-Identity is treated more strictly than message text, because there are fewer ways to write it: `--config-env=user.name=VAR` is resolved from the command's own assignments or the guard's environment, and a value the guard genuinely cannot read blocks as `unverifiableIdentity` rather than passing. Message files too large to read in full block as `unverifiableMessage`. A partial check is never reported as a pass.
+Identity is treated more strictly than message text, because there are fewer ways to write it: `--config-env=user.name=VAR` is resolved from the command's own assignments or the guard's environment, and a value the guard genuinely cannot read blocks as `unverifiableIdentity` rather than passing. Message files too large to read in full — or that exist and cannot be read at all — block as `unverifiableMessage`. A file that is simply *missing* is allowed, because git fails on it too and nothing gets authored. A partial check is never reported as a pass.
+
+### Bylines that arrive from somewhere else
+
+Two commands take their author and message from an object that already exists, so nothing incriminating appears in the command at all:
+
+```bash
+git cherry-pick <ref>      # copies the source commit's author AND message
+git commit -C <ref>        # same
+git am bot.patch           # takes both from the mail headers in the file
+```
+
+Both are read and checked. For a patch, only the headers and the message region are inspected — everything below the `---` separator is the diff, and reading it would block any patch that merely touches a file discussing these rules. An in-body `From:` overrides the header, as it does in git.
+
+`git am` with no file named — `cat bot.patch | git am`, `git am -`, `git am <(gen)` — blocks as `unverifiablePatch`. The bytes are in a pipe the guard does not own, and consuming them would take them away from git. This is stricter than the equivalent `git commit -F -`, deliberately: a commit has the `commit-msg` backstop below it, and `git am` does not run that hook at all, so refusing here is the only place the byline can be caught.
+
+The expected-human policy is not applied to a patch author. A mailed patch is somebody else's work by definition — preserving a contributor's authorship is the point of `git am` — so requiring a match with the operator would block the command's normal use. A tool or bot byline is still refused.
 
 ## Failure policy
 
@@ -140,6 +156,9 @@ ghostwriter/
 │   ├── attribution.js          the rules — attribution vs identity
 │   ├── git-surfaces.js         quote-aware command reader
 │   ├── git-identity.js         effective git identity
+│   ├── imported-authorship.js  bylines copied from a commit or a patch
+│   ├── patch.js                mbox headers and message region
+│   ├── surface-target.js       which directory / repository a surface targets
 │   ├── guard.js                the five-pass decision
 │   ├── hookEntrypoint/         vendored from factories/ (do not edit)
 │   └── runtime/                vendored from factories/ (do not edit)

--- a/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
+++ b/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
@@ -342,6 +342,21 @@ describe('scanCommand — identity surfaces', () => {
     }
   });
 
+  // An am that names no file reads its patch from a pipe. Reporting an empty
+  // list would let `cat bot.patch | git am` clear on a clean configured user.
+  it('records an am whose patch arrives on stdin', () => {
+    for (const command of ['cat bot.patch | git am', 'git am', 'git am -', 'git am <(gen)']) {
+      const surface = scanCommand(command).surfaces.find((entry) => entry.kind === 'am');
+      assert.equal(surface.patchStdin, true, command);
+    }
+  });
+
+  it('does not call a named patch or a resume form stdin', () => {
+    for (const command of ['git am p.mbox', 'git am < p.mbox', 'git am --continue']) {
+      assert.equal(onlySurface(command).patchStdin, false, command);
+    }
+  });
+
   it('reads a GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n identity pair', () => {
     const surface = onlySurface(
       `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=${TOOL} git commit -m x`

--- a/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
+++ b/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
@@ -357,6 +357,17 @@ describe('scanCommand — identity surfaces', () => {
     }
   });
 
+  // `--` ends option parsing in git. Without honouring it, a patch named
+  // `--continue` applies while reading here as a resume, and nothing is checked.
+  it('treats everything after `--` as a filename, as git does', () => {
+    const named = onlySurface('git am -- --continue');
+    assert.deepEqual(named.patchFiles, ['--continue']);
+    assert.equal(named.patchStdin, false);
+    assert.deepEqual(onlySurface('git am -- p.mbox').patchFiles, ['p.mbox']);
+    // A bare `--` still names nothing, so the patch is on stdin.
+    assert.equal(onlySurface('git am --').patchStdin, true);
+  });
+
   it('reads a GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n identity pair', () => {
     const surface = onlySurface(
       `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=${TOOL} git commit -m x`

--- a/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
+++ b/plugins/ghostwriter/lib/__tests__/git-surfaces.test.js
@@ -315,6 +315,33 @@ describe('scanCommand — identity surfaces', () => {
     assert.deepEqual(onlySurface('git commit -m x').authorRefs, []);
   });
 
+  // `git am` carries its author and its message INSIDE the file, so the file
+  // has to be collected — but as a patch, not as a message: only part of it is
+  // one, and the rest is a diff.
+  it('collects the patches an am would apply', () => {
+    assert.deepEqual(onlySurface('git am bot.patch').patchFiles, ['bot.patch']);
+    assert.deepEqual(onlySurface('git am -3 a.patch b.patch').patchFiles, ['a.patch', 'b.patch']);
+    assert.deepEqual(onlySurface('git am bot.patch').messageFiles, []);
+  });
+
+  it('reads a patch fed by a redirect, in either spelling', () => {
+    assert.deepEqual(onlySurface('git am < p.mbox').patchFiles, ['p.mbox']);
+    assert.deepEqual(onlySurface('git am <p.mbox').patchFiles, ['p.mbox']);
+  });
+
+  // Without the value-flag list `build` reads as a patch, and the guard then
+  // reports a directory it cannot inspect — a block on a valid command.
+  it('does not mistake a flag value for a patch', () => {
+    assert.deepEqual(onlySurface('git am --directory build p.mbox').patchFiles, ['p.mbox']);
+    assert.deepEqual(onlySurface('git am --exclude=doc/* p.mbox').patchFiles, ['p.mbox']);
+  });
+
+  it('collects nothing from the resume and abort forms', () => {
+    for (const command of ['git am --continue', 'git am --abort', 'git am --skip']) {
+      assert.deepEqual(onlySurface(command).patchFiles, [], command);
+    }
+  });
+
   it('reads a GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n identity pair', () => {
     const surface = onlySurface(
       `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=user.name GIT_CONFIG_VALUE_0=${TOOL} git commit -m x`

--- a/plugins/ghostwriter/lib/__tests__/guard.test.js
+++ b/plugins/ghostwriter/lib/__tests__/guard.test.js
@@ -22,6 +22,7 @@ const {
   inspectToolCall,
   renderBlock,
   readTextFile,
+  readFully,
   OVERRIDE_ENV,
   MAX_MESSAGE_FILE_BYTES,
 } = require('../guard');
@@ -440,6 +441,19 @@ describe('guard — bypasses that must stay closed', () => {
     }
   });
 
+  // A patch on stdin cannot be read: the bytes are in a pipe the guard does
+  // not own, and consuming them would take them from git. Stricter than
+  // `git commit -F -` on purpose — git runs no commit-msg hook for an am, so
+  // there is no later layer to catch it.
+  it('refuses a patch that arrives on stdin rather than clearing it', () => {
+    for (const command of ['cat bot.patch | git am', 'git am', 'git am -', 'git am <(gen)']) {
+      const verdict = inspect(command);
+      assert.equal(verdict.blocked, true, command);
+      assert.equal(verdict.rule, 'unverifiablePatch', command);
+      assert.equal(verdict.where, 'git am', command);
+    }
+  });
+
   it('blocks a patch it cannot read, and allows one that is not there', () => {
     const verdict = inspect('git am locked.patch', {
       readMessageFile: () => ({ text: '', unreadable: 'EACCES' }),
@@ -576,6 +590,38 @@ describe('guard — message files are read in full', () => {
     fs.mkdirSync(path.join(dir, 'notes'), { recursive: true });
     assert.equal(readTextFile(path.join(dir, 'notes'), dir).unreadable, 'EISDIR');
     assert.deepEqual(withRealReader('git commit -F notes'), { blocked: false });
+  });
+
+  // One readSync may return a prefix. Taking that as the whole file is the
+  // same mistake as sampling it — git reads the rest, the guard would not.
+  it('keeps reading until the buffer is full or the file ends', () => {
+    const file = path.join(dir, 'chunks.bin');
+    fs.writeFileSync(file, 'abcdefghij');
+    const fd = fs.openSync(file, 'r');
+    try {
+      const exact = Buffer.alloc(10);
+      assert.equal(readFully(fd, exact), 10);
+      assert.equal(exact.toString(), 'abcdefghij');
+      // A buffer past the end must stop at EOF rather than spin.
+      const roomy = Buffer.alloc(64);
+      assert.equal(readFully(fd, roomy), 10);
+      // And a short buffer fills exactly, leaving the rest unread.
+      const small = Buffer.alloc(4);
+      assert.equal(readFully(fd, small), 4);
+      assert.equal(small.toString(), 'abcd');
+    } finally {
+      fs.closeSync(fd);
+    }
+  });
+
+  it('inspects the tail of a multi-megabyte message, not just the head', () => {
+    const file = path.join(dir, 'tail.txt');
+    fs.writeFileSync(file, `feat: x\n\n${`${'x'.repeat(99)}\n`.repeat(40000)}`);
+    fs.appendFileSync(file, `Co-Authored-By: ${TOOL} <a@b>\n`);
+    assert.ok(fs.statSync(file).size > 4_000_000, 'fixture must span many read buffers');
+    const verdict = withRealReader(`git commit -F ${file}`);
+    assert.equal(verdict.blocked, true, 'a short read would have missed the suffix');
+    assert.equal(verdict.rule, 'aiCoAuthorTrailer');
   });
 
   // End to end on real bytes: the byline is inside the file, and the trailer

--- a/plugins/ghostwriter/lib/__tests__/guard.test.js
+++ b/plugins/ghostwriter/lib/__tests__/guard.test.js
@@ -454,6 +454,14 @@ describe('guard — bypasses that must stay closed', () => {
     }
   });
 
+  it('inspects a patch whose name looks like a resume flag', () => {
+    const verdict = inspect('git am -- --continue', {
+      readMessageFile: () => patch({ from: `${TOOL} <a@b>` }),
+    });
+    assert.equal(verdict.blocked, true, 'a file named --continue is still a patch');
+    assert.equal(verdict.where, 'the author in --continue');
+  });
+
   it('blocks a patch it cannot read, and allows one that is not there', () => {
     const verdict = inspect('git am locked.patch', {
       readMessageFile: () => ({ text: '', unreadable: 'EACCES' }),

--- a/plugins/ghostwriter/lib/__tests__/guard.test.js
+++ b/plugins/ghostwriter/lib/__tests__/guard.test.js
@@ -15,6 +15,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
 
 const {
   inspectCommand,
@@ -41,6 +42,36 @@ function inspect(command, overrides = {}) {
     expected: { emails: [], logins: [], configured: false },
     ...overrides,
   });
+}
+
+/**
+ * A mail-formatted patch, as `git format-patch` writes one.
+ *
+ * The diff deliberately CONTAINS an attribution trailer: excluding the diff is
+ * the behaviour under test, and a reader that inspected the whole file would
+ * block every case below — including the ones that must pass.
+ */
+function patch(overrides) {
+  const {
+    from = 'Ada Lovelace <ada@example.com>',
+    subject = 'feat: a change',
+    body = 'Why it changed.',
+  } = overrides || {};
+  return [
+    'From 8a3f4c2e0f9b Mon Sep 17 00:00:00 2001',
+    `From: ${from}`,
+    'Date: Mon, 2 Jun 2025 10:00:00 +0000',
+    `Subject: [PATCH v2 1/2] ${subject}`,
+    '',
+    body,
+    '---',
+    ' lib/rules.js | 1 +',
+    'diff --git a/lib/rules.js b/lib/rules.js',
+    '--- a/lib/rules.js',
+    '+++ b/lib/rules.js',
+    `+  reject('Co-Authored-By: ${TOOL} <a@b>');`,
+    '',
+  ].join('\n');
 }
 
 describe('guard — commands with nothing at stake', () => {
@@ -349,6 +380,80 @@ describe('guard — bypasses that must stay closed', () => {
     );
   });
 
+  // `git am` names a file and nothing else. Every other pass sees a clean
+  // command and a clean configured user; the byline is inside the patch.
+  it('blocks a patch authored by a tool', () => {
+    const verdict = inspect('git am bot.patch', {
+      readMessageFile: () => patch({ from: `${TOOL} <noreply@example.com>` }),
+    });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.where, 'the author in bot.patch');
+  });
+
+  it('blocks an attribution trailer in a patch message', () => {
+    const verdict = inspect('git am mail.patch', {
+      readMessageFile: () => patch({ body: `Fixes the thing.\n\nCo-Authored-By: ${TOOL} <a@b>` }),
+    });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.rule, 'aiCoAuthorTrailer');
+    assert.equal(verdict.where, 'the message in mail.patch');
+  });
+
+  // The diff below `---` is content. Reading it as a message would block any
+  // patch that touches a file discussing these rules — this plugin's own.
+  it('ignores the diff, so a patch that edits these rules still applies', () => {
+    assert.deepEqual(inspect('git am rules.patch', { readMessageFile: () => patch({}) }), {
+      blocked: false,
+    });
+  });
+
+  // An in-body `From:` is how a patch keeps its author through a mailing list
+  // that rewrites the envelope, and git prefers it over the header.
+  it('prefers the in-body From: over the mail header, as git does', () => {
+    const verdict = inspect('git am relayed.patch', {
+      readMessageFile: () =>
+        patch({ from: 'Ada <ada@example.com>', body: `From: ${TOOL} <a@b>\n\nreal body` }),
+    });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.where, 'the author in relayed.patch');
+  });
+
+  it('checks every patch in an mbox, not just the first', () => {
+    const verdict = inspect('git am series.mbox', {
+      readMessageFile: () => patch({}) + patch({ from: `${TOOL} <a@b>`, subject: 'feat: second' }),
+    });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.where, 'the author in series.mbox');
+  });
+
+  it('leaves a patch from another human alone — that is what am is for', () => {
+    const verdict = inspect('git am contributor.patch', {
+      expected: { emails: ['ada@example.com'], logins: [], configured: true },
+      readMessageFile: () => patch({ from: 'Grace Hopper <grace@example.com>' }),
+    });
+    assert.deepEqual(verdict, { blocked: false });
+  });
+
+  it('allows the resume and abort forms, which apply no patch', () => {
+    for (const command of ['git am --continue', 'git am --abort', 'git am --skip']) {
+      assert.deepEqual(inspect(command), { blocked: false }, command);
+    }
+  });
+
+  it('blocks a patch it cannot read, and allows one that is not there', () => {
+    const verdict = inspect('git am locked.patch', {
+      readMessageFile: () => ({ text: '', unreadable: 'EACCES' }),
+    });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.where, 'the patch locked.patch');
+    assert.deepEqual(
+      inspect('git am gone.patch', {
+        readMessageFile: () => ({ text: '', unreadable: 'ENOENT' }),
+      }),
+      { blocked: false }
+    );
+  });
+
   it('follows a GIT_DIR inherited from the session, not just the command', () => {
     const asked = [];
     inspect('git commit -m "feat: x"', {
@@ -440,12 +545,48 @@ describe('guard — message files are read in full', () => {
     assert.equal(verdict.rule, 'unverifiableMessage');
   });
 
-  it('treats an unreadable file as empty, not as a block', () => {
-    assert.deepEqual(readTextFile(path.join(dir, 'missing.txt'), dir), {
-      text: '',
-      truncated: false,
-    });
+  it('allows a missing file, which git would reject itself', () => {
+    assert.equal(readTextFile(path.join(dir, 'missing.txt'), dir).unreadable, 'ENOENT');
     assert.deepEqual(withRealReader('git commit -F missing.txt'), { blocked: false });
+  });
+
+  // A file that is THERE and unreadable is a message nobody saw. Clearing it
+  // would make `chmod 000` the cheapest way past every rule in the plugin.
+  it('blocks a file that exists but cannot be read', () => {
+    const read = { text: '', unreadable: 'EACCES' };
+    const verdict = inspect('git commit -F secret.txt', { readMessageFile: () => read });
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.rule, 'unverifiableMessage');
+    assert.match(verdict.evidence, /EACCES/);
+  });
+
+  // Reading a pipe is worse than useless: it reports size 0, so the check
+  // passes on an empty string, and it consumes the bytes git was going to use.
+  it('refuses to clear a message that is not a regular file', () => {
+    const fifo = path.join(dir, 'fifo');
+    const made = spawnSync('mkfifo', [fifo]);
+    if (made.status !== 0) return; // no mkfifo here — the unit case above covers it
+    assert.equal(readTextFile(fifo, dir).unreadable, 'ENOTREG');
+    const verdict = withRealReader(`git commit -F ${fifo}`);
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.rule, 'unverifiableMessage');
+  });
+
+  it('treats a directory named as a message file the way git does', () => {
+    fs.mkdirSync(path.join(dir, 'notes'), { recursive: true });
+    assert.equal(readTextFile(path.join(dir, 'notes'), dir).unreadable, 'EISDIR');
+    assert.deepEqual(withRealReader('git commit -F notes'), { blocked: false });
+  });
+
+  // End to end on real bytes: the byline is inside the file, and the trailer
+  // in the diff below it must not count against the patch.
+  it('reads a real patch file, headers only', () => {
+    fs.writeFileSync(path.join(dir, 'bot.patch'), patch({ from: `${TOOL} <a@b>` }));
+    fs.writeFileSync(path.join(dir, 'ok.patch'), patch({}));
+    const verdict = withRealReader('git am bot.patch');
+    assert.equal(verdict.blocked, true);
+    assert.equal(verdict.where, 'the author in bot.patch');
+    assert.deepEqual(withRealReader('git am ok.patch'), { blocked: false });
   });
 
   it('accepts a plain string from an injected reader', () => {

--- a/plugins/ghostwriter/lib/__tests__/patch.test.js
+++ b/plugins/ghostwriter/lib/__tests__/patch.test.js
@@ -1,0 +1,99 @@
+/**
+ * Unit tests for lib/patch.js — reading a byline out of a mail-formatted patch.
+ *
+ * The parser exists because `git am` puts the author and the message in the
+ * FILE, so these tests pin the two things that decide whether the guard sees
+ * the right text: which header wins, and where the message stops. The second
+ * matters most — a parser that runs into the diff reports every patch touching
+ * this plugin as an offender.
+ *
+ * Run with: node --test plugins/ghostwriter/lib/__tests__/patch.test.js
+ */
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { parsePatches } = require('../patch');
+
+const TOOL = ['Cl', 'aude'].join('');
+
+const MAIL = [
+  'From 8a3f4c2e0f9b1d Mon Sep 17 00:00:00 2001',
+  'From: Ada Lovelace <ada@example.com>',
+  'Date: Mon, 2 Jun 2025 10:00:00 +0000',
+  'Subject: [PATCH v2 3/7] feat: a change',
+  '',
+  'Why it changed.',
+  '',
+  '---',
+  ' lib/a.js | 2 +-',
+  'diff --git a/lib/a.js b/lib/a.js',
+  `+  reject('Co-Authored-By: ${TOOL} <a@b>');`,
+  '',
+].join('\n');
+
+describe('parsePatches', () => {
+  it('reads the author and the message out of a patch', () => {
+    const [mail] = parsePatches(MAIL);
+    assert.deepEqual(mail, {
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      message: 'feat: a change\n\nWhy it changed.',
+    });
+  });
+
+  // The whole reason the diff is excluded: this plugin's own source quotes the
+  // strings it rejects, and a patch that touches it must still be appliable.
+  it('stops at the diff separator', () => {
+    assert.ok(!parsePatches(MAIL)[0].message.includes('reject('));
+  });
+
+  it('strips the bracketed bookkeeping from the subject', () => {
+    const [mail] = parsePatches(MAIL);
+    assert.equal(mail.message.split('\n')[0], 'feat: a change');
+  });
+
+  // git prefers an in-body header, which is how a patch keeps its author
+  // through a mailing list that rewrites the envelope.
+  it('lets an in-body From: override the mail header', () => {
+    const [mail] = parsePatches(MAIL.replace('Why it changed.', `From: ${TOOL} <a@b>\n\nbody`));
+    assert.equal(mail.name, TOOL);
+    assert.equal(mail.email, 'a@b');
+    assert.equal(mail.message, 'feat: a change\n\nbody');
+  });
+
+  it('folds a continued header back onto one line', () => {
+    const folded = MAIL.replace(
+      'From: Ada Lovelace <ada@example.com>',
+      'From: Ada\n  Lovelace <ada@example.com>'
+    );
+    assert.equal(parsePatches(folded)[0].name, 'Ada Lovelace');
+  });
+
+  // Nothing is dropped when the address is unusual: the raw value stays in
+  // `name`, so it still reaches the identity rules.
+  it('keeps a bare address, and unquotes a quoted display name', () => {
+    assert.equal(
+      parsePatches(MAIL.replace('Ada Lovelace <ada@example.com>', 'bot@x'))[0].name,
+      'bot@x'
+    );
+    assert.equal(
+      parsePatches(MAIL.replace('Ada Lovelace <', '"Ada Lovelace" <'))[0].name,
+      'Ada Lovelace'
+    );
+  });
+
+  it('splits an mbox into one entry per patch', () => {
+    const series = MAIL + MAIL.replace('Ada Lovelace <ada@example.com>', `${TOOL} <a@b>`);
+    const mails = parsePatches(series);
+    assert.equal(mails.length, 2);
+    assert.deepEqual(
+      mails.map((mail) => mail.name),
+      ['Ada Lovelace', TOOL]
+    );
+  });
+
+  it('reports empty fields for text that is not a patch at all', () => {
+    assert.deepEqual(parsePatches(''), [{ name: '', email: '', message: '' }]);
+  });
+});

--- a/plugins/ghostwriter/lib/finding.js
+++ b/plugins/ghostwriter/lib/finding.js
@@ -21,8 +21,12 @@ function finding(result, where) {
 
 /** Accept either shape from an injected reader: a plain string or the record. */
 function normalizeRead(value) {
-  if (typeof value === 'string') return { text: value, truncated: false };
-  return { text: (value && value.text) || '', truncated: Boolean(value && value.truncated) };
+  if (typeof value === 'string') return { text: value, truncated: false, unreadable: '' };
+  return {
+    text: (value && value.text) || '',
+    truncated: Boolean(value && value.truncated),
+    unreadable: (value && value.unreadable) || '',
+  };
 }
 
 /** A file the guard could not read in full is not a file it can clear. */
@@ -33,4 +37,35 @@ const UNVERIFIABLE = Object.freeze({
   evidence: `larger than ${MAX_MESSAGE_FILE_BYTES} bytes`,
 });
 
-module.exports = { finding, normalizeRead, UNVERIFIABLE, MAX_MESSAGE_FILE_BYTES };
+/**
+ * Failures that mean there is nothing to read. git fails on these too — a
+ * missing file, a path through a non-directory, a directory named as a message
+ * — so the command never reaches a commit and there is nothing to clear.
+ */
+const ABSENT_CODES = new Set(['ENOENT', 'ENOTDIR', 'EISDIR']);
+
+/** Something IS there and the guard could not see it. */
+function unreadableFile(code) {
+  return {
+    rule: 'unverifiableMessage',
+    reason: 'the file could not be read, so the text it would author is unknown',
+    hint: 'Make the file readable, or pass the text inline, so the guard can check it.',
+    evidence: `read failed with ${code}`,
+  };
+}
+
+/**
+ * The finding a failed read warrants, or null when nothing was there to read.
+ *
+ * The distinction is the point: a file that is ABSENT authors nothing, but a
+ * file that exists and could not be read is a message the guard never saw.
+ * Reporting the second as clean would make an unreadable file the cheapest way
+ * past every rule in this plugin.
+ */
+function readFailure(read, where) {
+  if (read.truncated) return finding(UNVERIFIABLE, where);
+  if (!read.unreadable || ABSENT_CODES.has(read.unreadable)) return null;
+  return finding(unreadableFile(read.unreadable), where);
+}
+
+module.exports = { finding, normalizeRead, readFailure, UNVERIFIABLE, MAX_MESSAGE_FILE_BYTES };

--- a/plugins/ghostwriter/lib/git-surfaces.js
+++ b/plugins/ghostwriter/lib/git-surfaces.js
@@ -273,21 +273,32 @@ function readMessageArgs(argv, start, out) {
  * and clearing the command. The resume and abort forms legitimately name
  * nothing, which is what AM_CONTROL_FLAGS is for.
  */
-function classifyPatchArg(token) {
-  if (AM_CONTROL_FLAGS.has(token)) return { control: true };
+function classifyPatchArg(token, literal) {
   if (PROC_SUBST_RE.test(token)) return { stream: true };
   // `git am < p` splits into two tokens, so the name arrives on the next pass
-  // of the loop; `git am <p` carries it in this one.
+  // of the loop; `git am <p` carries it in this one. A redirect is the SHELL's,
+  // so it never reaches git's argv and `--` has no bearing on it.
   const redirect = REDIRECT_RE.exec(token);
   if (redirect) return { file: redirect[1] };
+  if (literal) return { file: token };
+  if (AM_CONTROL_FLAGS.has(token)) return { control: true };
   if (AM_VALUE_FLAGS.has(token)) return { skip: true };
   return token.startsWith('-') ? {} : { file: token };
 }
 
 function readPatchArgs(argv, start, out) {
   const seen = { control: false, stream: false };
+  // `--` ends option parsing in git, so everything after it is a filename
+  // however much it looks like a flag. Without that, `git am -- --continue`
+  // applies a patch named `--continue` while reading here as a resume, and
+  // neither imported-authorship check ever runs.
+  let literal = false;
   for (let i = start; i < argv.length; i++) {
-    const arg = classifyPatchArg(argv[i]);
+    if (!literal && argv[i] === '--') {
+      literal = true;
+      continue;
+    }
+    const arg = classifyPatchArg(argv[i], literal);
     seen.control = seen.control || Boolean(arg.control);
     seen.stream = seen.stream || Boolean(arg.stream);
     if (arg.file) out.patchFiles.push(arg.file);

--- a/plugins/ghostwriter/lib/git-surfaces.js
+++ b/plugins/ghostwriter/lib/git-surfaces.js
@@ -60,6 +60,24 @@ const AUTHOR_COPY_SUBCOMMANDS = new Set(['cherry-pick']);
 const REUSE_FLAGS = ['--reuse-message', '--reedit-message'];
 const REUSE_SHORT = new Set(['-C', '-c']);
 
+/**
+ * `git am` flags whose value is a SEPARATE token. Without them `--directory
+ * build` reads as a patch called `build`, and the guard would report a
+ * directory it cannot inspect. The `=` forms need no entry — they start with
+ * `-` and are skipped as flags.
+ */
+const AM_VALUE_FLAGS = new Set([
+  '--directory',
+  '--exclude',
+  '--include',
+  '--patch-format',
+  '--whitespace',
+  '--gpg-sign',
+  '-S',
+  '-p',
+  '-C',
+]);
+
 /** Subcommands that stamp a new object with the current committer identity. */
 const IDENTITY_SUBCOMMANDS = new Set([
   'commit',
@@ -221,6 +239,34 @@ function readMessageArgs(argv, start, out) {
   }
 }
 
+/**
+ * The patches `git am` would apply.
+ *
+ * They are the command's positional arguments, and they matter because the
+ * author and the message live INSIDE the file: `git am bot.patch` re-creates a
+ * bot's byline with nothing incriminating anywhere in the argv. They are kept
+ * apart from `messageFiles` because only part of a patch is a message — the
+ * diff below `---` is content, and reading the whole file as a message would
+ * block a patch that merely touches a file discussing these rules.
+ *
+ * `git am --continue` / `--abort` / `--skip` name no patch, so they collect
+ * nothing and the pass never runs.
+ */
+function readPatchArgs(argv, start, out) {
+  for (let i = start; i < argv.length; i++) {
+    const redirect = REDIRECT_RE.exec(argv[i]);
+    if (redirect) {
+      // `git am < p` splits into two tokens, so the name arrives on the next
+      // pass of this loop; `git am <p` carries it in this one.
+      if (redirect[1]) out.patchFiles.push(redirect[1]);
+    } else if (AM_VALUE_FLAGS.has(argv[i])) {
+      i++;
+    } else if (!argv[i].startsWith('-')) {
+      out.patchFiles.push(argv[i]);
+    }
+  }
+}
+
 function newSurface(kind, writesMessage, writesCommit, target) {
   return {
     kind,
@@ -231,6 +277,7 @@ function newSurface(kind, writesMessage, writesCommit, target) {
     configSources: target.configSources || {},
     messages: [],
     messageFiles: [],
+    patchFiles: [],
     identities: [],
     authorRefs: [],
   };
@@ -259,7 +306,10 @@ function authoringSurface(argv, found, env) {
     configSources: readConfigSources(env),
   };
   const surface = newSurface(found.subcommand, writesMessage, writesCommit, target);
-  readMessageArgs(argv, found.index + 1, surface);
+  // `am` names patches, not messages: its argument is a whole mail file, and
+  // routing it through the message reader would inspect the diff as prose.
+  if (found.subcommand === 'am') readPatchArgs(argv, found.index + 1, surface);
+  else readMessageArgs(argv, found.index + 1, surface);
   readAuthorRefs(found.subcommand, argv, found.index + 1, surface);
   readIdentities(argv, found.index, env, surface);
   return surface;

--- a/plugins/ghostwriter/lib/git-surfaces.js
+++ b/plugins/ghostwriter/lib/git-surfaces.js
@@ -78,6 +78,24 @@ const AM_VALUE_FLAGS = new Set([
   '-C',
 ]);
 
+/**
+ * `git am` forms that resume or drop an am already in progress. They apply no
+ * new patch, so naming no file is normal for them — without this list they
+ * would read as "the patch is on stdin" and block.
+ */
+const AM_CONTROL_FLAGS = new Set([
+  '--continue',
+  '--resolved',
+  '-r',
+  '--skip',
+  '--abort',
+  '--quit',
+  '--show-current-patch',
+]);
+
+/** `<(cmd)` — bash hands git a pipe, and the token is not a path at all. */
+const PROC_SUBST_RE = /^<\(/;
+
 /** Subcommands that stamp a new object with the current committer identity. */
 const IDENTITY_SUBCOMMANDS = new Set([
   'commit',
@@ -249,22 +267,33 @@ function readMessageArgs(argv, start, out) {
  * diff below `---` is content, and reading the whole file as a message would
  * block a patch that merely touches a file discussing these rules.
  *
- * `git am --continue` / `--abort` / `--skip` name no patch, so they collect
- * nothing and the pass never runs.
+ * An am that names NO patch reads one from stdin — `cat bot.patch | git am`,
+ * `git am -`, `git am <(gen)`. Those bytes are in a pipe the guard does not
+ * own, so it records `patchStdin` and refuses instead of finding an empty list
+ * and clearing the command. The resume and abort forms legitimately name
+ * nothing, which is what AM_CONTROL_FLAGS is for.
  */
+function classifyPatchArg(token) {
+  if (AM_CONTROL_FLAGS.has(token)) return { control: true };
+  if (PROC_SUBST_RE.test(token)) return { stream: true };
+  // `git am < p` splits into two tokens, so the name arrives on the next pass
+  // of the loop; `git am <p` carries it in this one.
+  const redirect = REDIRECT_RE.exec(token);
+  if (redirect) return { file: redirect[1] };
+  if (AM_VALUE_FLAGS.has(token)) return { skip: true };
+  return token.startsWith('-') ? {} : { file: token };
+}
+
 function readPatchArgs(argv, start, out) {
+  const seen = { control: false, stream: false };
   for (let i = start; i < argv.length; i++) {
-    const redirect = REDIRECT_RE.exec(argv[i]);
-    if (redirect) {
-      // `git am < p` splits into two tokens, so the name arrives on the next
-      // pass of this loop; `git am <p` carries it in this one.
-      if (redirect[1]) out.patchFiles.push(redirect[1]);
-    } else if (AM_VALUE_FLAGS.has(argv[i])) {
-      i++;
-    } else if (!argv[i].startsWith('-')) {
-      out.patchFiles.push(argv[i]);
-    }
+    const arg = classifyPatchArg(argv[i]);
+    seen.control = seen.control || Boolean(arg.control);
+    seen.stream = seen.stream || Boolean(arg.stream);
+    if (arg.file) out.patchFiles.push(arg.file);
+    if (arg.skip) i++;
   }
+  out.patchStdin = !seen.control && (seen.stream || out.patchFiles.length === 0);
 }
 
 function newSurface(kind, writesMessage, writesCommit, target) {
@@ -278,6 +307,7 @@ function newSurface(kind, writesMessage, writesCommit, target) {
     messages: [],
     messageFiles: [],
     patchFiles: [],
+    patchStdin: false,
     identities: [],
     authorRefs: [],
   };

--- a/plugins/ghostwriter/lib/guard.js
+++ b/plugins/ghostwriter/lib/guard.js
@@ -17,7 +17,9 @@
  *                           heredoc bodies, unquoted `$(…)`, chained writes
  *   5. published prose    — `gh pr/issue/release` bodies, titles and api fields
  *   6. the posting account— the account `gh` would publish as
- *   7. the repo identity  — what git would stamp, in the repository targeted
+ *   7. imported authorship— the byline and message inside a commit being
+ *                           reused, or inside a patch `git am` would apply
+ *   8. the repo identity  — what git would stamp, in the repository targeted
  *
  * A forge MCP call skips the parsing — its text arrives as named fields — and
  * is checked by the same rules. Its ACCOUNT cannot be checked at all: the
@@ -46,9 +48,11 @@ const {
   checkPostAccount,
   unverifiableAccount,
 } = require('./forge-guard');
+const { checkCopiedCommits, checkPatchFiles } = require('./imported-authorship');
+const { surfaceCwd, surfaceGitDir } = require('./surface-target');
 const { readExpectedIdentity } = require('./expected-identity');
 const { MAX_UNWRAP_DEPTH } = require('./command-scan');
-const { finding, normalizeRead, UNVERIFIABLE, MAX_MESSAGE_FILE_BYTES } = require('./finding');
+const { finding, normalizeRead, readFailure, MAX_MESSAGE_FILE_BYTES } = require('./finding');
 
 /** Operator override, honoured ONLY from the hook's own environment. */
 const OVERRIDE_ENV = 'GHOSTWRITER_ALLOW_ATTRIBUTION';
@@ -66,20 +70,35 @@ const ALLOW = Object.freeze({ blocked: false });
 /**
  * Read a message file in full.
  *
- * @returns {{text: string, truncated: boolean}} `truncated` means the file was
- *   too large to inspect — never that part of it was checked and passed.
+ * Three outcomes, and telling the last two apart is the whole point: the text,
+ * `truncated` for a file too large to inspect, or `unreadable` with the errno
+ * for one that is there and could not be read. Reporting that last case as an
+ * empty string would make an unreadable file the cheapest way past every rule
+ * in this plugin; `readFailure` decides which codes mean "nothing was there".
+ *
+ * Only REGULAR files are read. A FIFO — `git commit -F <(gen)` — reports size 0
+ * and yields its bytes exactly once, so reading it would both clear the check
+ * on an empty string and consume the data git was about to use. The open is
+ * NON-BLOCKING for the same reason: opening a FIFO for reading otherwise waits
+ * for a writer that may never arrive, and a guard that hangs is a guard that
+ * gets removed. Regular files ignore the flag.
+ *
+ * @returns {{text: string, truncated?: boolean, unreadable?: string}}
  */
 function readTextFile(filePath, cwd) {
   let fd;
   try {
-    fd = fs.openSync(path.resolve(cwd || process.cwd(), filePath), 'r');
-    const { size } = fs.fstatSync(fd);
-    if (size > MAX_MESSAGE_FILE_BYTES) return { text: '', truncated: true };
-    const buffer = Buffer.alloc(size);
-    const read = fs.readSync(fd, buffer, 0, size, 0);
-    return { text: buffer.toString('utf8', 0, read), truncated: false };
-  } catch {
-    return { text: '', truncated: false };
+    const flags = fs.constants.O_RDONLY | fs.constants.O_NONBLOCK;
+    fd = fs.openSync(path.resolve(cwd || process.cwd(), filePath), flags);
+    const stat = fs.fstatSync(fd);
+    if (stat.isDirectory()) return { text: '', unreadable: 'EISDIR' };
+    if (!stat.isFile()) return { text: '', unreadable: 'ENOTREG' };
+    if (stat.size > MAX_MESSAGE_FILE_BYTES) return { text: '', truncated: true };
+    const buffer = Buffer.alloc(stat.size);
+    const read = fs.readSync(fd, buffer, 0, stat.size, 0);
+    return { text: buffer.toString('utf8', 0, read) };
+  } catch (err) {
+    return { text: '', unreadable: (err && err.code) || 'EUNKNOWN' };
   } finally {
     if (fd !== undefined) {
       try {
@@ -130,32 +149,6 @@ function checkMessageArgs(surfaces) {
   return null;
 }
 
-/**
- * The directory this surface actually operates on. `git -C <dir> commit` reads
- * its config — and resolves a relative `-F` path — from there, not from the
- * shell's cwd, so both later passes have to follow it.
- */
-function surfaceCwd(surface, io) {
-  // `-C` compounds, so every value applies in order: `-C outer -C inner`
-  // lands in outer/inner. path.resolve does exactly that, absolutes included.
-  return surface.dirs && surface.dirs.length ? path.resolve(io.cwd, ...surface.dirs) : io.cwd;
-}
-
-/**
- * The repository whose config this surface commits under. `--git-dir` /
- * `GIT_DIR` select it independently of the process directory, so a command can
- * sit in a clean repo and author into another one.
- */
-function surfaceGitDir(surface, io) {
-  // A GIT_DIR already exported in the session reaches git without appearing in
-  // the command at all. The guard's own `git config` read inherits it too, so
-  // the two agree either way — but threading it explicitly makes that a stated
-  // contract rather than a coincidence, and keeps it right if the guard's
-  // environment ever stops matching the command's.
-  const selected = surface.gitDir || io.env.GIT_DIR;
-  return selected ? path.resolve(surfaceCwd(surface, io), selected) : null;
-}
-
 /** Pass 2 — every `-F` / `--file` / redirected message body, read in full. */
 function checkMessageFiles(surfaces, io) {
   for (const surface of surfaces) {
@@ -165,7 +158,8 @@ function checkMessageFiles(surfaces, io) {
       const read = normalizeRead(io.readMessageFile(file, surfaceCwd(surface, io)));
       const result = checkText(read.text);
       if (!result.ok) return finding(result, where);
-      if (read.truncated) return finding(UNVERIFIABLE, where);
+      const failed = readFailure(read, where);
+      if (failed) return failed;
     }
   }
   return null;
@@ -213,36 +207,6 @@ function checkRawCommand(command, surfaces) {
   return result.ok ? null : finding(result, 'the command text');
 }
 
-/**
- * A copied commit — `git cherry-pick <ref>`, `git commit -C <ref>`.
- *
- * BOTH halves ride along: the source commit's author, which the configured
- * identity pass would never see, and its message, which none of the message
- * passes receive because it appears nowhere in the command. Checking one and
- * not the other leaves exactly half the copy uninspected.
- */
-function checkCopiedCommit(surface, ref, io) {
-  const cwd = surfaceCwd(surface, io);
-  const source = io.resolveCommitInfo(cwd, surfaceGitDir(surface, io), ref);
-  const author = checkIdentity(source);
-  if (!author.ok) return finding(author, `the author copied from ${ref}`);
-  const expected = checkExpectedIdentity(source, io.expected);
-  if (!expected.ok) return finding(expected, `the author copied from ${ref}`);
-  const message = checkText(source.message);
-  if (!message.ok) return finding(message, `the message copied from ${ref}`);
-  return null;
-}
-
-function checkCopiedCommits(surfaces, io) {
-  for (const surface of surfaces) {
-    for (const ref of surface.authorRefs || []) {
-      const hit = checkCopiedCommit(surface, ref, io);
-      if (hit) return hit;
-    }
-  }
-  return null;
-}
-
 /** Pass 5 — the identity git would stamp on the object being written. */
 function checkEffectiveIdentity(surfaces, io) {
   const seen = new Set();
@@ -276,6 +240,7 @@ const COMMAND_PASSES = [
   (c) => checkRawPost(c.command, c.posts),
   (c) => checkPostAccount(c.posts, c.ctx),
   (c) => checkCopiedCommits(c.surfaces, c.ctx),
+  (c) => checkPatchFiles(c.surfaces, c.ctx),
   (c) => checkEffectiveIdentity(c.surfaces, c.ctx),
 ];
 

--- a/plugins/ghostwriter/lib/guard.js
+++ b/plugins/ghostwriter/lib/guard.js
@@ -48,7 +48,7 @@ const {
   checkPostAccount,
   unverifiableAccount,
 } = require('./forge-guard');
-const { checkCopiedCommits, checkPatchFiles } = require('./imported-authorship');
+const { checkCopiedCommits, checkStdinPatch, checkPatchFiles } = require('./imported-authorship');
 const { surfaceCwd, surfaceGitDir } = require('./surface-target');
 const { readExpectedIdentity } = require('./expected-identity');
 const { MAX_UNWRAP_DEPTH } = require('./command-scan');
@@ -66,6 +66,27 @@ const OVERRIDE_ENV = 'GHOSTWRITER_ALLOW_ATTRIBUTION';
  * clean. Blocking a 32 MiB commit message is not a cost worth optimising.
  */
 const ALLOW = Object.freeze({ blocked: false });
+
+/**
+ * Fill `buffer` from `fd`, looping until it is full or the file ends.
+ *
+ * ONE `readSync` is allowed to return fewer bytes than asked for — a signal
+ * arrives, the file lives on a network mount — and taking that prefix as the
+ * whole file is the same mistake as sampling it: git reads the rest, the guard
+ * does not. Stopping at a zero-length read is not that mistake; it is the end
+ * of a file that shrank since the stat, and what was read IS all of it.
+ *
+ * @returns {number} bytes actually read.
+ */
+function readFully(fd, buffer) {
+  let offset = 0;
+  while (offset < buffer.length) {
+    const read = fs.readSync(fd, buffer, offset, buffer.length - offset, offset);
+    if (read === 0) break;
+    offset += read;
+  }
+  return offset;
+}
 
 /**
  * Read a message file in full.
@@ -95,8 +116,7 @@ function readTextFile(filePath, cwd) {
     if (!stat.isFile()) return { text: '', unreadable: 'ENOTREG' };
     if (stat.size > MAX_MESSAGE_FILE_BYTES) return { text: '', truncated: true };
     const buffer = Buffer.alloc(stat.size);
-    const read = fs.readSync(fd, buffer, 0, stat.size, 0);
-    return { text: buffer.toString('utf8', 0, read) };
+    return { text: buffer.toString('utf8', 0, readFully(fd, buffer)) };
   } catch (err) {
     return { text: '', unreadable: (err && err.code) || 'EUNKNOWN' };
   } finally {
@@ -240,6 +260,7 @@ const COMMAND_PASSES = [
   (c) => checkRawPost(c.command, c.posts),
   (c) => checkPostAccount(c.posts, c.ctx),
   (c) => checkCopiedCommits(c.surfaces, c.ctx),
+  (c) => checkStdinPatch(c.surfaces),
   (c) => checkPatchFiles(c.surfaces, c.ctx),
   (c) => checkEffectiveIdentity(c.surfaces, c.ctx),
 ];
@@ -335,6 +356,7 @@ module.exports = {
   inspectToolCall,
   renderBlock,
   readTextFile,
+  readFully,
   OVERRIDE_ENV,
   MAX_MESSAGE_FILE_BYTES,
 };

--- a/plugins/ghostwriter/lib/imported-authorship.js
+++ b/plugins/ghostwriter/lib/imported-authorship.js
@@ -72,6 +72,33 @@ function checkCopiedCommits(surfaces, io) {
   return null;
 }
 
+/**
+ * `git am` reading its patch from stdin — `cat bot.patch | git am`, `git am -`,
+ * `git am <(gen)`.
+ *
+ * The guard cannot read that: the bytes are in a pipe it does not own, and
+ * consuming them would take them away from git. So the command is refused,
+ * like everything else this plugin cannot see.
+ *
+ * This is stricter than the equivalent `git commit -F -`, deliberately. A
+ * commit has a backstop — git runs `commit-msg` on the final message, after
+ * every expansion — and `git am` does not: it runs `applypatch-msg` and
+ * friends instead, so nothing downstream would ever see this patch. Refusing
+ * here is the only place the byline can be caught.
+ */
+function checkStdinPatch(surfaces) {
+  if (!surfaces.some((surface) => surface.patchStdin)) return null;
+  return finding(
+    {
+      rule: 'unverifiablePatch',
+      reason: 'the patch arrives on stdin, so its author and message cannot be read',
+      hint: 'Write the patch to a file and pass it to git am, so it can be checked.',
+      evidence: 'git am with no patch file named',
+    },
+    'git am'
+  );
+}
+
 /** One mail file, which may hold several patches — `git am` applies them all. */
 function checkPatchFile(surface, file, io) {
   const read = normalizeRead(io.readMessageFile(file, surfaceCwd(surface, io)));
@@ -95,4 +122,4 @@ function checkPatchFiles(surfaces, io) {
   return null;
 }
 
-module.exports = { checkCopiedCommits, checkPatchFiles };
+module.exports = { checkCopiedCommits, checkStdinPatch, checkPatchFiles };

--- a/plugins/ghostwriter/lib/imported-authorship.js
+++ b/plugins/ghostwriter/lib/imported-authorship.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * imported-authorship.js — the passes for a byline the command does not write,
+ * but IMPORTS from something that already carries one.
+ *
+ * Two commands do it, and neither shows the offending text anywhere in its
+ * arguments:
+ *
+ *   git cherry-pick <ref> / git commit -C <ref>
+ *     copies an existing commit's author AND its message onto a new commit.
+ *   git am <patch>
+ *     takes both from the mail headers inside the file.
+ *
+ * Every other pass clears these. The message passes find no `-m` text because
+ * there is none; the identity passes find a configured user who really is a
+ * clean human. The byline that lands is somebody else's, and it arrives from a
+ * place only a read can reach.
+ */
+
+const { checkText, checkIdentity, checkExpectedIdentity } = require('./attribution');
+const { finding, normalizeRead, readFailure } = require('./finding');
+const { surfaceCwd, surfaceGitDir } = require('./surface-target');
+const { parsePatches } = require('./patch');
+
+/**
+ * An author and a message that arrive together, judged together.
+ *
+ * `expectHuman` is the one axis on which the two sources differ. A cherry-pick
+ * lands a commit in your own history, so an expected-human policy applies to
+ * it. A mailed patch is somebody else's work by definition — preserving a
+ * contributor's authorship is the entire purpose of `git am`, and demanding
+ * that it match the operator would block the command's normal use. What must
+ * never ride in either way is a TOOL byline, which is checked for both.
+ */
+function checkAuthored(source, io, where, expectHuman) {
+  const author = checkIdentity(source);
+  if (!author.ok) return finding(author, where.author);
+  if (expectHuman) {
+    const expected = checkExpectedIdentity(source, io.expected);
+    if (!expected.ok) return finding(expected, where.author);
+  }
+  const message = checkText(source.message);
+  return message.ok ? null : finding(message, where.message);
+}
+
+/**
+ * A copied commit — `git cherry-pick <ref>`, `git commit -C <ref>`.
+ *
+ * BOTH halves ride along: the source commit's author, which the configured
+ * identity pass would never see, and its message, which none of the message
+ * passes receive because it appears nowhere in the command. Checking one and
+ * not the other leaves exactly half the copy uninspected.
+ */
+function checkCopiedCommit(surface, ref, io) {
+  const source = io.resolveCommitInfo(surfaceCwd(surface, io), surfaceGitDir(surface, io), ref);
+  return checkAuthored(
+    source,
+    io,
+    { author: `the author copied from ${ref}`, message: `the message copied from ${ref}` },
+    true
+  );
+}
+
+function checkCopiedCommits(surfaces, io) {
+  for (const surface of surfaces) {
+    for (const ref of surface.authorRefs || []) {
+      const hit = checkCopiedCommit(surface, ref, io);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+/** One mail file, which may hold several patches — `git am` applies them all. */
+function checkPatchFile(surface, file, io) {
+  const read = normalizeRead(io.readMessageFile(file, surfaceCwd(surface, io)));
+  const failed = readFailure(read, `the patch ${file}`);
+  if (failed) return failed;
+  const where = { author: `the author in ${file}`, message: `the message in ${file}` };
+  for (const mail of parsePatches(read.text)) {
+    const hit = checkAuthored(mail, io, where, false);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function checkPatchFiles(surfaces, io) {
+  for (const surface of surfaces) {
+    for (const file of surface.patchFiles || []) {
+      const hit = checkPatchFile(surface, file, io);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+module.exports = { checkCopiedCommits, checkPatchFiles };

--- a/plugins/ghostwriter/lib/patch.js
+++ b/plugins/ghostwriter/lib/patch.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * patch.js — the author and the commit message inside a mail-formatted patch.
+ *
+ * `git am` takes its byline from the PATCH, not from the command. The argv
+ * carries a filename and nothing else, so every other pass in this plugin sees
+ * a clean command: no `-m` text, no `--author`, and a configured identity that
+ * really is a clean human. The `From:` header inside the file is what lands as
+ * the author of the commit, and the `Subject:` plus body is what lands as its
+ * message.
+ *
+ * ONLY those regions are returned. Everything from the `---` separator down is
+ * the diff — content, not attribution — and inspecting it would block a patch
+ * whose only offence is touching a file that discusses these rules. That is the
+ * same reason the prose passes blank code fences before reading a PR body.
+ */
+
+/** A header line: `From: …`, `Subject: …`. */
+const HEADER_RE = /^([A-Za-z-]+):\s*(.*)$/;
+/** The mbox record separator — `From <sha> <date>`, with no colon. */
+const MBOX_FROM_RE = /^From \S/;
+/** `Subject: [PATCH v2 3/7] real subject` — the brackets are bookkeeping. */
+const SUBJECT_PREFIX_RE = /^\s*(?:\[[^\]]*\]\s*)*/;
+/** `Name <addr@example.com>`. */
+const ADDRESS_RE = /^\s*(.*?)\s*<([^>]*)>\s*$/;
+/** The line git treats as the end of the commit message. */
+const DIFF_SEPARATOR = '---';
+
+/**
+ * git honours `From:` and `Subject:` written at the TOP OF THE BODY, and they
+ * OVERRIDE the mail headers — that is how a patch keeps its original author
+ * through a mailing list that rewrites the envelope. Reading only the headers
+ * reads an author git is not going to use.
+ */
+const IN_BODY_KEYS = new Set(['from', 'subject', 'date']);
+
+/** One mbox may carry many patches; `git am` applies every one of them. */
+function splitMails(text) {
+  const mails = [];
+  let current = [];
+  for (const line of String(text).split('\n')) {
+    if (MBOX_FROM_RE.test(line) && current.length) {
+      mails.push(current);
+      current = [];
+    }
+    current.push(line);
+  }
+  if (current.length) mails.push(current);
+  return mails;
+}
+
+/** Fold a continuation line (`\n `) back onto the header it belongs to. */
+function continuation(headers, last, line) {
+  if (!last) return false;
+  headers[last] = `${headers[last]} ${line.trim()}`;
+  return true;
+}
+
+/** The mail headers, and the index of the first line after them. */
+function readHeaders(lines) {
+  const headers = {};
+  let last = null;
+  let i = MBOX_FROM_RE.test(lines[0] || '') ? 1 : 0;
+  for (; i < lines.length; i++) {
+    if (!lines[i].trim()) return { headers, index: i + 1 };
+    if (/^\s/.test(lines[i]) && continuation(headers, last, lines[i])) continue;
+    const match = HEADER_RE.exec(lines[i]);
+    if (!match) return { headers, index: i };
+    last = match[1].toLowerCase();
+    headers[last] = match[2];
+  }
+  return { headers, index: lines.length };
+}
+
+/** Apply the in-body overrides, returning where the prose actually starts. */
+function readInBodyHeaders(lines, start, headers) {
+  let i = start;
+  while (i < lines.length && !lines[i].trim()) i++;
+  for (; i < lines.length; i++) {
+    const match = HEADER_RE.exec(lines[i]);
+    if (!match || !IN_BODY_KEYS.has(match[1].toLowerCase())) break;
+    headers[match[1].toLowerCase()] = match[2];
+  }
+  return i;
+}
+
+/** The body, stopping where the diff begins. */
+function readBody(lines, start) {
+  const body = [];
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i].trimEnd() === DIFF_SEPARATOR) break;
+    body.push(lines[i]);
+  }
+  return body.join('\n').trim();
+}
+
+/**
+ * @returns {{name: string, email: string, message: string}} the author and the
+ *   message this mail would commit as. An address with no angle brackets keeps
+ *   its whole value as the name, so it is still checked rather than dropped.
+ */
+function parseMail(lines) {
+  const { headers, index } = readHeaders(lines);
+  const bodyStart = readInBodyHeaders(lines, index, headers);
+  const address = ADDRESS_RE.exec(headers.from || '');
+  const subject = (headers.subject || '').replace(SUBJECT_PREFIX_RE, '').trim();
+  return {
+    name: ((address ? address[1] : headers.from) || '').replace(/^"|"$/g, '').trim(),
+    email: address ? address[2].trim() : '',
+    message: [subject, readBody(lines, bodyStart)].filter(Boolean).join('\n\n'),
+  };
+}
+
+/** Every patch in a mail file, in the order `git am` would apply them. */
+function parsePatches(text) {
+  return splitMails(text).map(parseMail);
+}
+
+module.exports = { parsePatches };

--- a/plugins/ghostwriter/lib/surface-target.js
+++ b/plugins/ghostwriter/lib/surface-target.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/**
+ * surface-target.js — where a surface actually operates.
+ *
+ * A git command does not necessarily act on the shell's directory or on the
+ * repository it is sitting in, and every pass that reads something from disk
+ * has to follow it there: a relative `-F` path, a `git config` read, and a ref
+ * lookup all resolve against the target, not against the caller.
+ */
+
+const path = require('node:path');
+
+/**
+ * The directory this surface operates on.
+ *
+ * `-C` COMPOUNDS: `git -C outer -C inner` lands in `outer/inner`, so every
+ * value applies in order rather than the last one winning. path.resolve does
+ * exactly that, absolute segments included.
+ */
+function surfaceCwd(surface, io) {
+  return surface.dirs && surface.dirs.length ? path.resolve(io.cwd, ...surface.dirs) : io.cwd;
+}
+
+/**
+ * The repository whose config this surface commits under. `--git-dir` /
+ * `GIT_DIR` select it independently of the process directory, so a command can
+ * sit in a clean repo and author into another one.
+ */
+function surfaceGitDir(surface, io) {
+  // A GIT_DIR already exported in the session reaches git without appearing in
+  // the command at all. The guard's own `git config` read inherits it too, so
+  // the two agree either way — but threading it explicitly makes that a stated
+  // contract rather than a coincidence, and keeps it right if the guard's
+  // environment ever stops matching the command's.
+  const selected = surface.gitDir || io.env.GIT_DIR;
+  return selected ? path.resolve(surfaceCwd(surface, io), selected) : null;
+}
+
+module.exports = { surfaceCwd, surfaceGitDir };


### PR DESCRIPTION
Follow-up to #784. Four gaps, all in the layer that **finds** the text rather than in the rules that judge it — the rules themselves are unchanged.

## 1. `git am` never had its patch read

`git am` was already classified as an authoring command, but the patch file was never collected. That matters because the byline and the message live *inside* the file:

- the argv carries a filename and nothing else, so the message passes find no `-m` text and the identity passes find a configured user who really is a clean human;
- the `From:` header in the patch becomes the author of the commit that lands.

`git am bot.patch` therefore re-created a tool byline with nothing incriminating anywhere in the command.

Patch files are now collected (`patchFiles` on the surface, kept separate from `messageFiles`) and parsed by a new `lib/patch.js`:

- **headers and message region only.** Everything below the `---` separator is the diff — content, not attribution. Reading it would block any patch that touches a file discussing these rules, starting with this plugin's own source.
- **an in-body `From:` wins over the mail header**, as it does in git — that is how a patch keeps its author through a mailing list that rewrites the envelope.
- **every mail in an mbox is checked**, not just the first.
- flag values are not mistaken for patches: without that, `git am --directory build p.mbox` would read `build` as a patch and then report a directory it cannot inspect.
- `--` is honoured, so `git am -- --continue` applies a patch named `--continue` rather than reading as a resume.

One deliberate asymmetry with cherry-pick: the expected-human policy (`GHOSTWRITER_HUMAN_EMAIL`) is **not** applied to a patch author. A mailed patch is somebody else's work by definition — preserving a contributor's authorship is the entire point of `git am` — so requiring it to match the operator would block the command's normal use. A tool byline is still refused either way.

## 2. A patch fed on stdin was cleared, not refused

`cat bot.patch | git am`, bare `git am`, `git am -` and `git am <(gen)` all name no file, so the new patch list came back empty and the command cleared on a clean configured identity. The guard cannot read those bytes — they are in a pipe it does not own, and consuming them would take them away from git — so all four now block as `unverifiablePatch`. The resume and abort forms (`--continue`, `--resolved`/`-r`, `--skip`, `--abort`, `--quit`, `--show-current-patch`) name nothing legitimately and stay allowed.

This is stricter than the equivalent `git commit -F -`, which the README documents as an accepted limit, and the difference is the point: a commit has a backstop below it, because git runs `commit-msg` on the final message after every expansion. **`git am` does not run that hook at all** — it runs `applypatch-msg` and friends — so nothing downstream would ever see the patch. Refusing at this layer is the only place the byline can be caught.

## 3. An unreadable file was reported as clean

`readTextFile` returned `{ text: '', truncated: false }` for *every* failure, so a file the guard could not open read as an empty, perfectly clean message. That contradicted the plugin's own stated rule — what it cannot verify, it refuses — which it already applied to oversized files. `chmod 000` was the cheapest way past every check in the plugin.

Reads now distinguish two cases:

| outcome | codes | verdict |
| --- | --- | --- |
| absent | `ENOENT`, `ENOTDIR`, `EISDIR` | allow — git fails on these too, so nothing gets authored |
| unreadable | `EACCES` and everything else | block as `unverifiableMessage` |

Two related fixes in the same reader:

- **only regular files are read.** A FIFO — `git commit -F <(gen)` — reports size 0, so reading it would both clear the check on an empty string *and* consume the bytes git was about to use.
- **the open is non-blocking.** Opening a FIFO for reading otherwise waits for a writer that may never arrive; a guard that hangs is a guard that gets removed. This one was found by the test, not by inspection — the FIFO case hung the suite for the full timeout.

## 4. A short read passed as a complete file

One `fs.readSync` may return fewer bytes than asked for. Taking that prefix as the whole file is the same mistake as sampling it, which this reader's own comment warns against — git reads the rest, the guard would not. Reads now loop until the buffer fills or the file ends.

A zero-length read deliberately does *not* fail: that is a file which shrank between the `fstat` and the read, and the bytes obtained genuinely are all of it.

## Structure

To keep every file under the 400-line gate, the copied-commit and patch passes moved to `lib/imported-authorship.js` ("a byline the command does not write, but imports from something that already carries one") and the target-resolution helpers to `lib/surface-target.js`. No behaviour change in the move. `readPatchArgs` tripped cognitive-complexity 15 once the stdin cases landed; the per-argument classification was split out rather than allowlisted.

## Verification

- 224 ghostwriter tests pass (was 193 on #784; +31 covering all four fixes)
- full repo suite: 9098 pass / 0 fail / 4 skipped
- `pnpm quality` exit 0, `pnpm format:check` clean, all six lint scripts OK
- **no `.quality-exceptions` entries added**

Tests worth calling out: a real patch file read end-to-end from disk; a patch whose *diff* contains an attribution trailer, which must still apply; a 4 MB message whose trailer sits at the very end; and the FIFO and directory cases against the real filesystem.

README updated with the imported-byline section, the stdin refusal and its rationale, and the new modules.